### PR TITLE
Prepare second docs artifact, for human consumption

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,11 +40,25 @@ jobs:
         shell: bash
         run: |
           tox -edocs
-      - name: Upload docs artifact
-        if: always()
+      - name: Upload docs artifact for GitHub Pages
         uses: actions/upload-pages-artifact@v3
         with:
           path: docs/_build/html
+
+      # Provide a nicely named artifact that extracts into an
+      # identically named subdirectory.
+      - name: Prepare nice docs artifact for humans
+        if: always()
+        shell: bash
+        run: |
+          mkdir artifact
+          cp -a docs/_build/html artifact/qiskit-addon-utils-htmldocs
+      - name: Upload nice docs artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qiskit-addon-utils-htmldocs
+          path: ./artifact
 
   deploy:
     name: Deploy docs


### PR DESCRIPTION
This is what it would look like if we were to generate a second docs artifact, meant for human consumption.  The reason we might want to do this because some of us (me) will be more likely to download and look at a docs preview if the artifact is nicer to work with.  The reason we might not want to do this is because it adds lines to our CI configuration.

Follow-up to https://github.com/Qiskit/qiskit-addon-utils/pull/5#discussion_r1747243086 and #8.

-----

UPDATE: actually, after trying to work with the github-pages artifact, I am much in favor of this.  Working with that one basically involves

```sh
mkdir /tmp/newdir
cd /tmp/newdir
unzip '~/Downloads/github-pages (39).zip'
tar xf artifact.tar
```
while this artifact for humans can be extracted easily anywhere using `unzip` without causing much harm (everything in a single subdirectory with the same name).