### PR TITLE
Set `prerelease: false` in github-release-from-tag workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Publish release
 on:
   push:
     tags:
-      - "[0-9]+.[0-9]+.[0-9]+*"
+      - "[0-9]+.[0-9]+.[0-9]+"
 
 jobs:
 
@@ -19,6 +19,7 @@ jobs:
         uses: ghalactic/github-release-from-tag@v5
         if: github.ref_type == 'tag'
         with:
+          prerelease: false
           token: ${{ secrets.GITHUB_TOKEN }}
           generateReleaseNotes: "true"
 


### PR DESCRIPTION
Currently, the [github-release-from-tag action](https://github.com/ghalactic/github-release-from-tag?tab=readme-ov-file#release-stability) creates every release as a pre-release because the major version number is zero.  I can think of [plenty of reasons](https://0ver.org/#notable-zerover-projects) that default may not be suitable for every project, and I plan to raise the issue with the author(s) of the action that this behavior ought to be configurable.  However, in the meantime, we could either (i) edit each release immediately after it occurs to make it a release, not a pre-release, or (ii) merge something like this PR, which means the release workflow would no longer support pre-releases (e.g., x.y.z-dev, c.f. github [filter patterns](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet)), which is a bit unfortunate but probably fine for us in the foreseeable future.