### PR TITLE
Improve CI speed

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -41,6 +41,4 @@ jobs:
         shell: bash
         run: |
           toxpyversion=$(echo ${{ matrix.python-version }} | sed -E 's/^([0-9]+)\.([0-9]+).*$/\1\2/')
-          tox -epy${toxpyversion}
-          tox -epy${toxpyversion}-notebook
-          tox -edoctest
+          tox -epy${toxpyversion}-all

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -41,6 +41,4 @@ jobs:
         shell: bash
         run: |
           toxpyversion=$(echo ${{ matrix.python-version }} | sed -E 's/^([0-9]+)\.([0-9]+).*$/\1\2/')
-          tox -epy${toxpyversion}
-          tox -epy${toxpyversion}-notebook
-          tox -edoctest
+          tox -epy${toxpyversion}-all

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -37,6 +37,4 @@ jobs:
         shell: bash
         run: |
           toxpyversion=$(echo ${{ matrix.python-version }} | sed -E 's/^([0-9]+)\.([0-9]+).*$/\1\2/')
-          tox -epy${toxpyversion}
-          tox -epy${toxpyversion}-notebook
-          tox -edoctest
+          tox -epy${toxpyversion}-all

--- a/test/README.md
+++ b/test/README.md
@@ -1,6 +1,6 @@
 # Test environments
 
-This repository's tests and development automation tasks are organized using [tox], a command-line CI frontend for Python projects.  tox is typically used during local development and is also invoked from this repository's GitHub Actions [workflows](../.github/workflows/).
+This repository's tests and development automation tasks are organized using [tox], a command-line CI frontend for Python projects.  [tox] is typically used during local development and is also invoked from this repository's GitHub Actions [workflows](../.github/workflows/).
 
 tox can be installed by running `pip install tox`.
 
@@ -59,6 +59,14 @@ The `doctest` environment uses [doctest] to execute the code snippets that are e
 
 ```sh
 $ tox -e doctest
+```
+
+## Test "all" environments
+
+To improve the speed of the GitHub Actions [workflows](../.github/workflows/), this environment runs all the Python unittests, Jupyter notebooks, and doctests in one go using [pytest]. It is essentially equivalent to running the three previous tox environments but instead of using isolated installations for each, all the tests run in the same environment, reducing the setup overhead.
+
+```sh
+$ tox -e py310-all
 ```
 
 ## Coverage environment

--- a/tox.ini
+++ b/tox.ini
@@ -41,12 +41,20 @@ commands =
   pytest --nbmake --nbmake-timeout=3000 {posargs} docs/
 
 [testenv:doctest]
-basepython = python3.10
 extras =
   test
   doctest
 commands =
   pytest --doctest-plus --doctest-only
+
+[testenv:{,py-,py3-,py39-,py310-,py311-,py312-}all]
+extras =
+  test
+  doctest
+  nbtest
+  notebook-dependencies
+commands =
+  pytest --doctest-plus --nbmake --nbmake-timeout=3000 {posargs} qiskit_addon_utils/ docs/ test/
 
 [testenv:coverage]
 basepython = python3.10


### PR DESCRIPTION
The speed of the CI (mostly the development tests) has a noticeable overhead because three separate tox environments are used for the Python unittests, Jupyter notebook tests, and doctests.

This PR introduces a new tox environment which combines all of these tests into one target, removing the three-fold tox environment setup overhead.