### PR TITLE
ci: allow different Python versions for doctests

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -43,4 +43,4 @@ jobs:
           toxpyversion=$(echo ${{ matrix.python-version }} | sed -E 's/^([0-9]+)\.([0-9]+).*$/\1\2/')
           tox -epy${toxpyversion}
           tox -epy${toxpyversion}-notebook
-          tox -edoctest
+          tox -epy${toxpyversion}-doctest

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -43,4 +43,4 @@ jobs:
           toxpyversion=$(echo ${{ matrix.python-version }} | sed -E 's/^([0-9]+)\.([0-9]+).*$/\1\2/')
           tox -epy${toxpyversion}
           tox -epy${toxpyversion}-notebook
-          tox -edoctest
+          tox -epy${toxpyversion}-doctest

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -39,4 +39,4 @@ jobs:
           toxpyversion=$(echo ${{ matrix.python-version }} | sed -E 's/^([0-9]+)\.([0-9]+).*$/\1\2/')
           tox -epy${toxpyversion}
           tox -epy${toxpyversion}-notebook
-          tox -edoctest
+          tox -epy${toxpyversion}-doctest

--- a/test/README.md
+++ b/test/README.md
@@ -53,12 +53,12 @@ The `notebook` and `py##-notebook` environments invoke [nbmake] to ensure that a
 $ tox -e py310-notebook
 ```
 
-## Doctest environment
+## Doctest environments
 
-The `doctest` environment uses [doctest] to execute the code snippets that are embedded into the documentation strings. The tests get run using [pytest].
+The `doctest` environments use [doctest] to execute the code snippets that are embedded into the documentation strings. The tests get run using [pytest].
 
 ```sh
-$ tox -e doctest
+$ tox -e py310-doctest
 ```
 
 ## Coverage environment

--- a/tox.ini
+++ b/tox.ini
@@ -40,13 +40,12 @@ extras =
 commands =
   pytest --nbmake --nbmake-timeout=3000 {posargs} docs/
 
-[testenv:doctest]
-basepython = python3.10
+[testenv:{,py-,py3-,py39-,py310-,py311-,py312-}doctest]
 extras =
   test
   doctest
 commands =
-  pytest --doctest-plus --doctest-only
+  pytest --doctest-plus --doctest-only {posargs}
 
 [testenv:coverage]
 basepython = python3.10


### PR DESCRIPTION
Extracts the updates to the `doctest` environment per https://github.com/Qiskit/qiskit-addon-utils/pull/17#discussion_r1752610538