### PR TITLE
ci: pin development versions to commit SHAs

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -28,14 +28,30 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install dependencies (development versions)
+      - name: Determine development versions
+        shell: bash
+        run: |
+          # NOTE: by determining the current git commit SHAs, we can ensure that
+          # the individually run tox environments indeed actually use the exact
+          # same versions (which may not be the case if at the exact time a new
+          # commit gets added to the respective repositories).
+          # Additionally, using these commit SHAs ensures that the locally built
+          # Python wheels get cached, ensuring a faster tox environment setup
+          # for the multiple jobs below.
+          QISKIT_SHA=$(git ls-remote "https://github.com/Qiskit/qiskit" | grep HEAD | awk '{print $1}')
+          echo "QISKIT_SHA=$QISKIT_SHA" >> "$GITHUB_ENV"
+          echo "Using Qiskit/qiskit @ $QISKIT_SHA"
+          QISKIT_IBM_RUNTIME_SHA=$(git ls-remote "https://github.com/Qiskit/qiskit-ibm-runtime" | grep HEAD | awk '{print $1}')
+          echo "QISKIT_IBM_RUNTIME_SHA=$QISKIT_IBM_RUNTIME_SHA" >> "$GITHUB_ENV"
+          echo "Using Qiskit/qiskit-ibm-runtime @ $QISKIT_IBM_RUNTIME_SHA"
+      - name: Pinning development versions
         shell: bash
         run: |
           python -m pip install --upgrade pip tox
           python -m pip install extremal-python-dependencies==0.0.3
           extremal-python-dependencies pin-dependencies \
-              "qiskit @ git+https://github.com/Qiskit/qiskit.git" \
-              "qiskit-ibm-runtime @ git+https://github.com/Qiskit/qiskit-ibm-runtime.git" \
+              "qiskit @ git+https://github.com/Qiskit/qiskit.git@$QISKIT_SHA" \
+              "qiskit-ibm-runtime @ git+https://github.com/Qiskit/qiskit-ibm-runtime.git@$QISKIT_IBM_RUNTIME_SHA" \
               --inplace
       - name: Test using tox environment
         shell: bash


### PR DESCRIPTION
This PR determines the latest commit SHA for the development packages that we test against.
This has two benefits:

1. if a PR were to be merged to either of them between the execution of the multiple `tox` targets, different versions would be used for a single CI job. This prevents that by fixing the commit SHA once.
2. pip will automatically cache locally built wheels for fixed commit SHAs [1] which should avoid the slow build process that resulted from the repeated wheel building.


> Changed in version 20.0: pip now caches wheels when building from an immutable Git reference (i.e. a commit hash). [quoted from [1]]

[1]: https://pip.pypa.io/en/stable/topics/caching/#locally-built-wheels