### PR TITLE
ci: Upload to Coveralls always

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -34,8 +34,10 @@ jobs:
         run: |
           tox -e coverage
       - name: Convert to lcov
+        if: always()
         run: coverage3 lcov -o coveralls.lcov
       - name: Upload report to Coveralls
+        if: always()
         uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Let's make the coveralls comment be displayed even when the coverage job fails, as it might be in a repo that requires a certain threshold of test coverage.