### PR TITLE
ci: Include distribution assets in each GitHub release

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -40,6 +40,5 @@ jobs:
         if: always()
         uses: coverallsapp/github-action@v2
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           file: coveralls.lcov
           format: lcov

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,42 +8,63 @@ on:
 
 jobs:
 
-  github:
-    name: github
+  build:
+    name: build distribution
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout tag
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+      - name: Install pypa/build tool
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install build
+      - name: Build distribution
+        run: |
+          python -m build
+      - name: Store the distribution packages
+        uses: actions/upload-artifact@v4
         with:
-          ref: ${{ github.ref_name }}
+          name: python-package-distributions
+          path: dist/
+
+  github:
+    name: publish to github
+    runs-on: ubuntu-latest
+    needs:
+      - build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
+        with:
+          name: python-package-distributions
+          path: dist/
       - name: Publish release
         uses: ghalactic/github-release-from-tag@v5
         if: github.ref_type == 'tag'
         with:
           prerelease: false
-          token: ${{ secrets.GITHUB_TOKEN }}
           generateReleaseNotes: "true"
+          assets: |
+            - path: dist/*
 
   pypi:
-    name: pypi
+    name: publish to pypi
     runs-on: ubuntu-latest
-    needs: github
+    needs:
+      - build
+      - github
     environment:
       name: pypi
       url: https://pypi.org/p/qiskit-addon-utils
     permissions:
       id-token: write
     steps:
-      - name: Checkout tag
-        uses: actions/checkout@v4
+      - name: Download all the dists
+        uses: actions/download-artifact@v4
         with:
-          ref: ${{ github.ref_name }}
-      - name: Install `build` tool
-        run: |
-          python -m pip install --upgrade pip
-          pip install build
-      - name: Build distribution
-        run: |
-          python -m build
+          name: python-package-distributions
+          path: dist/
       - name: Publish release to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This is only a draft for now.  I still need to test it in a private repository.

References:
- https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
- https://github.com/ghalactic/github-release-from-tag