### PR TITLE
Fix GitHub source code links for decorated functions

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -148,9 +148,7 @@ def linkcode_resolve(domain, info):
         return None
 
     def is_valid_code_object(obj):
-        return (
-            inspect.isclass(obj) or inspect.ismethod(obj) or inspect.isfunction(obj)
-        )
+        return inspect.isclass(obj) or inspect.ismethod(obj) or inspect.isfunction(obj)
 
     obj = module
     for part in info["fullname"].split("."):
@@ -163,7 +161,7 @@ def linkcode_resolve(domain, info):
 
     # Unwrap decorators. This requires they used `functools.wrap()`.
     while hasattr(obj, "__wrapped__"):
-        obj = getattr(obj, "__wrapped__")
+        obj = obj.__wrapped__
         if not is_valid_code_object(obj):
             return None
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,17 +147,26 @@ def linkcode_resolve(domain, info):
     if module is None or "qiskit_addon_utils" not in module_name:
         return None
 
+    def is_valid_code_object(obj):
+        return (
+            inspect.isclass(obj) or inspect.ismethod(obj) or inspect.isfunction(obj)
+        )
+
     obj = module
     for part in info["fullname"].split("."):
         try:
             obj = getattr(obj, part)
         except AttributeError:
             return None
-        is_valid_code_object = (
-            inspect.isclass(obj) or inspect.ismethod(obj) or inspect.isfunction(obj)
-        )
-        if not is_valid_code_object:
+        if not is_valid_code_object(obj):
             return None
+
+    # Unwrap decorators. This requires they used `functools.wrap()`.
+    while hasattr(obj, "__wrapped__"):
+        obj = getattr(obj, "__wrapped__")
+        if not is_valid_code_object(obj):
+            return None
+
     try:
         full_file_name = inspect.getsourcefile(obj)
     except TypeError:


### PR DESCRIPTION
This is the same change as https://github.com/Qiskit/qiskit-ibm-runtime/pull/1960, ported to here.  The patch was created using `gh pr checkout 1960; git format-patch HEAD^`, and applied here using `git am -C1 <filename>`.