### PR TITLE
Add explicit support for Python 3.13

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.9, 3.12]
+        python-version: [3.9, 3.13]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -21,10 +21,10 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         include:
           - os: macos-latest
-            python-version: "3.12"
+            python-version: "3.13"
           - os: windows-latest
             python-version: "3.12"
     steps:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Scientific/Engineering :: Physics",
 ]
 

--- a/releasenotes/notes/python-3.13-9a82a16e34e2c58d.yaml
+++ b/releasenotes/notes/python-3.13-9a82a16e34e2c58d.yaml
@@ -1,0 +1,5 @@
+---
+upgrade:
+  - |
+    This release adds support for Python 3.13.  No code changes were necessary,
+    so older releases are expected to work on Python 3.13 too.

--- a/releasenotes/notes/python-3.13-9a82a16e34e2c58d.yaml
+++ b/releasenotes/notes/python-3.13-9a82a16e34e2c58d.yaml
@@ -1,5 +1,5 @@
 ---
-upgrade:
+other:
   - |
     This release adds support for Python 3.13.  No code changes were necessary,
     so older releases are expected to work on Python 3.13 too.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.4.3
-envlist = py{39,310,311,312}{,-notebook}, lint, coverage, docs, doctest
+envlist = py{39,310,311,312,313}{,-notebook}, lint, coverage, docs, doctest
 isolated_build = True
 
 [testenv]
@@ -36,14 +36,14 @@ commands =
   typos
   reno lint
 
-[testenv:{,py-,py3-,py39-,py310-,py311-,py312-}notebook]
+[testenv:{,py-,py3-,py39-,py310-,py311-,py312-,py313-}notebook]
 extras =
   nbtest
   notebook-dependencies
 commands =
   pytest --nbmake --nbmake-timeout=3000 {posargs} docs/
 
-[testenv:{,py-,py3-,py39-,py310-,py311-,py312-}doctest]
+[testenv:{,py-,py3-,py39-,py310-,py311-,py312-,py313-}doctest]
 extras =
   test
   doctest


### PR DESCRIPTION
As with https://github.com/Qiskit/qiskit-addon-cutting/pull/648#issuecomment-2400430055, I am so far unable to update Windows to Python 3.13 because there is not yet a wheel for aer.