### PR TITLE
Use `matrix.os` instead of fixed operating system

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   tests:
     name: development version tests (${{ matrix.os }}, ${{ matrix.python-version }})
-    runs-on: {{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       max-parallel: 4

--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   tests:
     name: development version tests (${{ matrix.os }}, ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: {{ matrix.os }}
     timeout-minutes: 30
     strategy:
       max-parallel: 4

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   tests:
     name: minimum version tests (${{ matrix.os }}, ${{ matrix.python-version }})
-    runs-on: {{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     strategy:
       max-parallel: 4

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   tests:
     name: minimum version tests (${{ matrix.os }}, ${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    runs-on: {{ matrix.os }}
     timeout-minutes: 30
     strategy:
       max-parallel: 4


### PR DESCRIPTION
I noticed this typo in another project; I was very confused when I changed the OS in the matrix, as it led to the job name changing but not the actual OS.  This fixes that.