### PR TITLE
Replace pydocstyle with Ruff

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -139,6 +139,7 @@ GITHUB_BRANCH = determine_github_branch()
 
 
 def linkcode_resolve(domain, info):
+    """Add links to GitHub source code."""
     if domain != "py":
         return None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,7 @@ select = [
     "I",   # isort
     "E",   # pycodestyle
     "W",   # pycodestyle
+    "D",   # pydocstyle
     "F",   # pyflakes
     "RUF", # ruff
     "UP",  # pyupgrade
@@ -152,8 +153,12 @@ ignore = [
 max-args = 6
 
 [tool.ruff.lint.extend-per-file-ignores]
+"test/**.py" = [
+    "D",    # pydocstyle
+]
 "docs/**/*" = [
     "E402", # module level import not at top of file
+    "D",    # pydocstyle
 ]
 
 [tool.ruff.lint.flake8-copyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,6 @@ lint = [
     "mypy==1.11.2",
     "pylint==3.3.1",
     "reno>=4.1",
-    "toml>=0.9.6",
 ]
 notebook-dependencies = [
     "qiskit-addon-utils",
@@ -156,9 +155,9 @@ max-args = 6
 "test/**.py" = [
     "D",    # pydocstyle
 ]
-"docs/**/*" = [
+"docs/**" = [
     "E402", # module level import not at top of file
-    "D",    # pydocstyle
+    "D100", # missing docstring in public module
 ]
 
 [tool.ruff.lint.flake8-copyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ style = [
 ]
 lint = [
     "qiskit-addon-utils[style]",
-    "pydocstyle==6.3.0",
     "mypy==1.11.2",
     "pylint==3.3.1",
     "reno>=4.1",
@@ -171,5 +170,8 @@ notice-rgx = """
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals\\.
 """
+
+[tool.ruff.lint.pydocstyle]
+convention = "google"
 
 [tool.typos.default.extend-words]

--- a/qiskit_addon_utils/coloring/automatic_coloring.py
+++ b/qiskit_addon_utils/coloring/automatic_coloring.py
@@ -20,8 +20,7 @@ import rustworkx as rx
 
 
 def auto_color_edges(edges: Sequence[tuple[int, int]]) -> dict[tuple[int, int], int]:
-    """
-    Color the input edges of an undirected graph such that no two incident edges share a color.
+    """Color the input edges of an undirected graph such that no two incident edges share a color.
 
     Args:
         edges: The edges describing an undirected graph.

--- a/qiskit_addon_utils/coloring/validation.py
+++ b/qiskit_addon_utils/coloring/validation.py
@@ -18,8 +18,7 @@ from collections import defaultdict
 
 
 def is_valid_edge_coloring(coloring: dict[tuple[int, int], int]) -> bool:
-    """
-    Check whether an edge coloring scheme is valid.
+    """Check whether an edge coloring scheme is valid.
 
     An edge coloring is valid if no two edges of the same color share a node.
 

--- a/qiskit_addon_utils/problem_generators/generate_time_evolution_circuit.py
+++ b/qiskit_addon_utils/problem_generators/generate_time_evolution_circuit.py
@@ -26,8 +26,7 @@ def generate_time_evolution_circuit(
     synthesis: EvolutionSynthesis | None = None,
     time: float = 1.0,
 ) -> QuantumCircuit:
-    """
-    Model the time evolution of an operator.
+    """Model the time evolution of an operator.
 
     .. plot::
         :include-source:

--- a/qiskit_addon_utils/problem_generators/generate_xyz_hamiltonian.py
+++ b/qiskit_addon_utils/problem_generators/generate_xyz_hamiltonian.py
@@ -61,8 +61,7 @@ def generate_xyz_hamiltonian(
     pauli_order_strategy: PauliOrderStrategy = PauliOrderStrategy.ColorThenInteraction,
     coloring: dict[tuple[int, int], int] | None = None,
 ) -> SparsePauliOp:
-    r"""
-    Generate a connectivity-aware qubit operator representing a quantum XYZ-type model.
+    r"""Generate a connectivity-aware qubit operator representing a quantum XYZ-type model.
 
     This function implements the following Hamiltonian:
 

--- a/qiskit_addon_utils/slicing/combine_slices.py
+++ b/qiskit_addon_utils/slicing/combine_slices.py
@@ -22,8 +22,7 @@ from qiskit import QuantumCircuit
 def combine_slices(
     slices: Sequence[QuantumCircuit], include_barriers: bool = False
 ) -> QuantumCircuit | None:
-    """
-    Combine N-qubit slices of a circuit into a single circuit.
+    """Combine N-qubit slices of a circuit into a single circuit.
 
     Args:
         slices: The N-qubit circuit slices.

--- a/qiskit_addon_utils/slicing/slice_by_depth.py
+++ b/qiskit_addon_utils/slicing/slice_by_depth.py
@@ -19,8 +19,7 @@ from qiskit.converters import circuit_to_dag, dag_to_circuit
 
 
 def slice_by_depth(circuit: QuantumCircuit, max_slice_depth: int) -> list[QuantumCircuit]:
-    """
-    Split a ``QuantumCircuit`` into slices based on depth.
+    """Split a ``QuantumCircuit`` into slices based on depth.
 
     This function transforms the input circuit into a :class:`~qiskit.dagcircuit.DAGCircuit` and
     batches the sequence of depth-1 layers output from :meth:`~qiskit.dagcircuit.DAGCircuit.layers`

--- a/qiskit_addon_utils/slicing/slice_by_gate_types.py
+++ b/qiskit_addon_utils/slicing/slice_by_gate_types.py
@@ -22,8 +22,7 @@ from .transpiler.passes import CollectOpType
 
 
 def slice_by_gate_types(circuit: QuantumCircuit) -> list[QuantumCircuit]:
-    """
-    Split a ``QuantumCircuit`` into depth-1 slices of operations of the same type.
+    """Split a ``QuantumCircuit`` into depth-1 slices of operations of the same type.
 
     .. warning::
        Note: Adjacent slices sharing no qubits in common may be ordered arbitrarily.

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ extras =
 commands =
   ruff format qiskit_addon_utils/ docs/ test/
   ruff check --fix qiskit_addon_utils/ docs/ test/
+  ruff check --fix --select D qiskit_addon_utils/
   nbqa ruff --fix docs/
 
 [testenv:lint]
@@ -27,9 +28,9 @@ extras =
 commands =
   ruff format --check qiskit_addon_utils/ docs/ test/
   ruff check qiskit_addon_utils/ docs/ test/
+  ruff check --select D qiskit_addon_utils/
   ruff check --preview --select CPY001 --exclude "*.ipynb" qiskit_addon_utils/ test/
   nbqa ruff docs/
-  pydocstyle qiskit_addon_utils/
   mypy qiskit_addon_utils/
   pylint -rn qiskit_addon_utils/ test/
   nbqa pylint -rn docs/

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,6 @@ extras =
 commands =
   ruff format qiskit_addon_utils/ docs/ test/
   ruff check --fix qiskit_addon_utils/ docs/ test/
-  ruff check --fix --select D qiskit_addon_utils/
   nbqa ruff --fix docs/
 
 [testenv:lint]
@@ -28,7 +27,6 @@ extras =
 commands =
   ruff format --check qiskit_addon_utils/ docs/ test/
   ruff check qiskit_addon_utils/ docs/ test/
-  ruff check --select D qiskit_addon_utils/
   ruff check --preview --select CPY001 --exclude "*.ipynb" qiskit_addon_utils/ test/
   nbqa ruff docs/
   mypy qiskit_addon_utils/


### PR DESCRIPTION
Pydocstyle was deprecated in favor of Ruff. Ruff has the exact same lints via the D ruleset.

As before, we only run the doc checks on source code and not tests.