### PR TITLE
Pass `GITHUB_BASE_REF` and `GITHUB_REF_NAME` in docs tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -65,6 +65,10 @@ extras =
   docs
 commands =
   sphinx-build -j auto -W -T --keep-going -b html {posargs} {toxinidir}/docs/ {toxinidir}/docs/_build/html
+passenv =
+  CI
+  GITHUB_BASE_REF
+  GITHUB_REF_NAME
 
 [testenv:docs-clean]
 skip_install = true


### PR DESCRIPTION
I realized that all the addons forget to pass these two github variables, so the source links are always to the main branch.

https://github.com/Qiskit/qiskit-addon-utils/blob/2068732f5f1c3666c2bc61b974d7ef0d0c1cfa13/docs/conf.py#L150-L158