### PR TITLE
Show inheritance in inlined classes in docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -81,6 +81,7 @@ autoclass_content = "both"
 autodoc_typehints = "description"
 autodoc_default_options = {
     "inherited-members": None,
+    "show-inheritance": True,
 }
 napoleon_google_docstring = True
 napoleon_numpy_docstring = False


### PR DESCRIPTION
This was an oversight. We already show inheritance for dedicated class pages from `.. autosummary::`, but not inlined classes from `.. autodoc::`.