### PR TITLE
ci: align Python version of tox and Github action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip


### PR DESCRIPTION
~CI did not fail here, yet (not sure why not)~, but I am anticipating failures requiring a fix similar to https://github.com/Qiskit/qiskit-addon-mpf/pull/44 and https://github.com/Qiskit/qiskit-addon-obp/pull/46.

EDIT: Just noticed that the Sphinx CI job got skipped in #64 and, hence, I did not see the failure :+1:

I would assume this has to do with some change in the underlying Github actions runner which might have had multiple Python versions available in the past (for whatever reason), thus hiding this problem.