### PR TITLE
ci: minor CI fixes

### DIFF
--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -26,7 +26,7 @@ jobs:
           - os: macos-latest
             python-version: "3.13"
           - os: windows-latest
-            python-version: "3.12"
+            python-version: "3.13"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,7 +169,7 @@ max-args = 6
 notice-rgx = """
 # This code is a Qiskit project.
 #
-# \\(C\\) Copyright IBM 2024\\.
+# \\(C\\) Copyright IBM \\d{4}((,\\s)\\d{4})*\\.
 #
 # This code is licensed under the Apache License, Version 2\\.0\\. You may
 # obtain a copy of this license in the LICENSE\\.txt file in the root directory


### PR DESCRIPTION
Just found these minor nitpicks in the CI setup.

The change of the Python version of the Windows tests will require an update to the branch protection rules.