### PR TITLE
Update license specification for PEP 639

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling>=1.27.0"]
 build-backend = "hatchling.build"
 
 [project]
@@ -7,7 +7,8 @@ name = "qiskit-addon-utils"
 version = "0.1.0"
 readme = "README.md"
 description = "Utilities to support workflows leveraging Qiskit addons"
-license = {file = "LICENSE.txt"}
+license = "Apache-2.0"
+license-files = ["LICENSE.txt"]
 classifiers = [
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",


### PR DESCRIPTION
There is some more info at https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license-and-license-files.

I see no deprecation warning yet using the latest version of hatchling, so there is no urgency in merging this.