### PR TITLE
Use `realpath` for absolute `file:` urls

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -50,8 +50,8 @@ jobs:
         shell: bash
         run: >-
           extremal-python-dependencies pin-dependencies --inplace
-          "qiskit @ file:$(echo qiskit/dist/*.whl)"
-          "qiskit-ibm-runtime @ file:$(echo qiskit-ibm-runtime/dist/*.whl)"
+          "qiskit @ file:$(realpath qiskit/dist/*.whl)"
+          "qiskit-ibm-runtime @ file:$(realpath qiskit-ibm-runtime/dist/*.whl)"
       - name: Test using tox environment
         run: |
           tox -e py,notebook,doctest --parallel --parallel-no-spinner


### PR DESCRIPTION
maturin does not like relative paths, as we saw in a CI failure at https://github.com/Qiskit/qiskit-addon-sqd/pull/222.

This updates the "development version tests" to use absolute paths.