### PR TITLE
Adds handling of clbits when slicing by gate types

### DIFF
--- a/qiskit_addon_utils/slicing/slice_by_gate_types.py
+++ b/qiskit_addon_utils/slicing/slice_by_gate_types.py
@@ -49,8 +49,9 @@ def slice_by_gate_types(circuit: QuantumCircuit) -> list[QuantumCircuit]:
         # NOTE: due to our transpiler pass above, we know that each op_node in this circuit will be
         # an Instruction instance representing a slice
         qargs = [circuit.find_bit(q).index for q in op_node.qargs]
-        qc = QuantumCircuit(circuit.num_qubits)
-        qc.append(op_node.op, qargs)
+        cargs = [circuit.find_bit(c).index for c in op_node.cargs]
+        qc = QuantumCircuit(circuit.num_qubits, circuit.num_clbits)
+        qc.append(op_node.op, qargs, cargs)
         slices.append(qc.decompose())
 
     return slices

--- a/releasenotes/notes/support_clbits_in_slice_by_gate_types-972e5c49ca478743.yaml
+++ b/releasenotes/notes/support_clbits_in_slice_by_gate_types-972e5c49ca478743.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Support circuits that include classical bits when slicing a circuit by gate types.
+    See `#115 <https://github.com/Qiskit/qiskit-addon-utils/issues/115>` for details.

--- a/test/slicing/test_slice_by_gate_types.py
+++ b/test/slicing/test_slice_by_gate_types.py
@@ -57,3 +57,19 @@ class TestSliceByGateTypes(unittest.TestCase):
                 self.assertEqual(targets[i][0], op_name)
                 for inst in slice_.data:
                     self.assertEqual(op_name, inst.operation.name)
+        with self.subTest("Circuit with classical bits"):
+            qc = QuantumCircuit(2)
+            qc.x(0)
+            qc.x(1)
+            qc.cx(0, 1)
+            qc.measure_all()  # Add classical bits to the circuit
+            slices = slice_by_gate_types(qc)
+            self.assertEqual(4, len(slices))
+            targets = (("x", 2), ("cx", 1), ("barrier", 1), ("measure", 2))
+            for i, slice_ in enumerate(slices):
+                self.assertEqual(qc.num_clbits, slice_.num_clbits)
+                self.assertEqual(targets[i][1], len(slice_.data))
+                op_name = slice_.data[0].operation.name
+                self.assertEqual(targets[i][0], op_name)
+                for inst in slice_.data:
+                    self.assertEqual(op_name, inst.operation.name)


### PR DESCRIPTION
Adds supports for slicing a circuit by gate type if the circuit include classical bits.

Fixes #115 