### PR TITLE
Simpler exp val

### DIFF
--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -93,7 +93,8 @@ def executor_expectation_values(
         ValueError if the number of entries in `basis_dict` does not equal the length of `bool_array` along `meas_basis_axis`.
     """
     ##### VALIDATE INPUTS:
-    avg_axis: tuple(int) = _validate_avg_axis(avg_axis, len(bool_array.shape))
+    avg_ax: tuple[int] = _validate_avg_axis(avg_axis, len(bool_array.shape))
+    # change name to make linter happy
 
     if meas_basis_axis is None:
         if len(basis_dict) != 1:

--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -412,9 +412,9 @@ def _bitarray_expectation_value(
     with np.errstate(divide="ignore"):
         expvals_each_term /= shots
         sq_expvals_each_term /= shots
-        expvals_each_term[~np.isfinite(expvals_each_term)] = np.nan
-        sq_expvals_each_term[~np.isfinite(expvals_each_term)] = np.nan
         variances_each_term = np.clip(sq_expvals_each_term - expvals_each_term**2, 0, None) / shots
+    expvals_each_term[~np.isfinite(expvals_each_term)] = np.nan
+    variances_each_term[~np.isfinite(variances_each_term)] = np.nan
 
     # len(all_coeffs) == number of bit terms == expvals_each_term.shape[-1], so broadcasts:
     # TODO: test case of empty observable

--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -385,9 +385,9 @@ def _bitarray_expectation_value(
     parities = (outcomes & mask_z).bitcount() % 2
 
     # Compute the coefficients of 0 and 1 components.
-    nulled_by_0_projector = np.any((outcomes & mask_0).array, axis=-1)
-    nulled_by_1_projector = np.any((~outcomes & mask_1).array, axis=-1)
-    coeffs_01 = ~np.logical_or(nulled_by_0_projector, nulled_by_1_projector)
+    nulled_by_projector = np.any((outcomes & mask_0).array, axis=-1)
+    nulled_by_projector |= np.any((~outcomes & mask_1).array, axis=-1)
+    coeffs_01 = ~nulled_by_projector
 
     # Compute expectation values
     shape = np.broadcast_shapes(outcomes.shape, mask_z.shape)

--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -93,7 +93,7 @@ def executor_expectation_values(
         ValueError if the number of entries in `basis_dict` does not equal the length of `bool_array` along `meas_basis_axis`.
     """
     ##### VALIDATE INPUTS:
-    avg_axis = _validate_avg_axis(avg_axis, len(bool_array.shape))
+    avg_axis: tuple(int) = _validate_avg_axis(avg_axis, len(bool_array.shape))
 
     if meas_basis_axis is None:
         if len(basis_dict) != 1:
@@ -109,6 +109,8 @@ def executor_expectation_values(
             postselect_mask = postselect_mask.reshape((1, *postselect_mask.shape))
         meas_basis_axis = 0
         avg_axis = tuple(a + 1 for a in avg_axis)
+    elif meas_basis_axis < 0:
+        raise ValueError("meas_basis_axis must be nonnegative.")
 
     if len(basis_dict) != bool_array.shape[meas_basis_axis]:
         raise ValueError(
@@ -157,13 +159,31 @@ def executor_expectation_values(
     ##### PEC SIGNS:
     if pauli_signs is not None:
         bool_array, basis_dict, net_signs = _apply_pec_signs(bool_array, basis_dict, pauli_signs)
-    else:
-        net_signs = np.zeros(bool_array.shape[:-2], dtype=bool)
-    # For PEC, we will need to apply a rescaling factor gamma later when computing expectation values.
+        # For PEC, we will need to multiply by gamma later when computing expectation values.
+        if gamma_factor is None:
+            # If gamma not provided, estimate it empirically, for each requested expectation value:
+            num_minus = np.count_nonzero(net_signs, axis=avg_axis)
+            num_plus = np.count_nonzero(~net_signs, axis=avg_axis)
+            num_twirls = num_plus + num_minus
+            gamma_factor = num_twirls / (num_plus - num_minus)
+    elif gamma_factor is None:
+        gamma_factor = 1
+
+    ##### If other axes are to be averaged over, do so by first absorbing them into the shots axis:
+    if avg_axis:
+        # move avg_axis just before shots axis (just before axis -2):
+        axis_positions_before_shots = -2 - np.arange(len(avg_axis))
+        bool_array = np.moveaxis(bool_array, avg_axis, axis_positions_before_shots)
+        # flatten into shots axis (preserve sizes of other axes, including bits axis):
+        bool_array = np.reshape(bool_array, (*bool_array.shape[:-2-len(avg_axis)], -1, bool_array.shape[-1]))
+
+        # update others to match:
+        num_shots_kept = np.sum(num_shots_kept, avg_axis)
+        meas_basis_axis -= np.sum(np.asarray(avg_axis) < meas_basis_axis)
 
     ##### ACCUMULATE CONTRIBUTIONS FROM EACH MEAS BASIS:
     barray = BitArray.from_bool_array(bool_array, "little")
-    output_shape_each_obs = np.delete(barray.shape, (meas_basis_axis, *avg_axis))
+    output_shape_each_obs = np.delete(barray.shape, meas_basis_axis)
     mean_each_observable = np.zeros((num_observables, *output_shape_each_obs), dtype=float)
     var_each_observable = np.zeros((num_observables, *output_shape_each_obs), dtype=float)
 
@@ -175,7 +195,6 @@ def executor_expectation_values(
         idx = tuple([*skip_axes, meas_basis_idx])
         barray_this_basis = barray[idx]
         num_kept = num_shots_kept[idx]
-        signs = net_signs[idx]
         basis_rescale_factors = (
             rescale_factors[meas_basis_idx] if rescale_factors is not None else None
         )
@@ -188,32 +207,12 @@ def executor_expectation_values(
             rescale_each_observable=basis_rescale_factors,
         )
 
-        variances = standard_errs**2
-        del standard_errs
-
-        ## AVERAGE OVER SPECIFIED AXES ("TWIRLS"):
-        # Update indexing since we already sliced away meas_basis axis:
-        avg_axis_ = tuple(a if a < meas_basis_axis else a - 1 for a in avg_axis)
-
-        if gamma_factor is not None:
-            axes = tuple(ax for i, ax in enumerate(signs.shape) if i not in avg_axis_)
-            rescaling = np.full(axes, gamma_factor)
-        else:
-            num_minus = np.count_nonzero(signs, axis=avg_axis_)
-            num_plus = np.count_nonzero(~signs, axis=avg_axis_)
-            num_twirls = num_plus + num_minus
-            rescaling = num_twirls / (num_plus - num_minus)
-
-        # Will weight each twirl by its fraction of kept shots.
-        # If no postselection, weighting reduces to dividing by num_twirls:
-        num_kept_each_avg = np.sum(num_kept, axis=avg_axis_)
-        weights = num_kept / np.expand_dims(num_kept_each_avg, avg_axis_)
         # Append axis for observables being evaluated (to match axis in `means`):
-        weights = weights[..., np.newaxis]
-        rescaling = rescaling[..., np.newaxis]
-        means = rescaling * np.sum(means * weights, axis=avg_axis_)
+        if np.shape(gamma_factor):
+            gamma_factor = gamma_factor[..., np.newaxis]
+        means = gamma_factor * means
         # Propagate uncertainties:
-        variances = rescaling**2 * np.sum(variances * weights**2, axis=avg_axis_)
+        variances = (gamma_factor*standard_errs)**2
         # Move observable axis from end to front:
         mean_each_observable += np.moveaxis(means, -1, 0)
         var_each_observable += np.moveaxis(variances, -1, 0)

--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -167,7 +167,7 @@ def executor_expectation_values(
             num_twirls = num_plus + num_minus
             gamma_factor = num_twirls / (num_plus - num_minus)
     elif gamma_factor is None:
-        gamma_factor = 1.
+        gamma_factor = 1.0
 
     ##### If other axes are to be averaged over, do so by first absorbing them into the shots axis:
     if avg_axis:
@@ -210,7 +210,7 @@ def executor_expectation_values(
         )
 
         # Append axis for observables being evaluated (to match axis in `means`):
-        if np.shape(gamma_factor):
+        if np.iterable(gamma_factor):
             gamma_factor = gamma_factor[..., np.newaxis]
         means = gamma_factor * means
         # Propagate uncertainties:

--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -394,7 +394,6 @@ def _bitarray_expectation_value(
     expvals_each_term = np.zeros(shape, dtype=float)
     sq_expvals_each_term = np.zeros_like(expvals_each_term)
 
-    # Combine masks to get coeff for each shot (-1, 0, or 1)
     if np.all(coeffs_01):
         # We can do a faster computation of pure Pauli parities
         expvals_each_term += outcomes.num_shots - 2 * np.sum(parities, axis=-1, dtype=int)

--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -210,7 +210,7 @@ def executor_expectation_values(
         )
 
         # Append axis for observables being evaluated (to match axis in `means`):
-        if np.iterable(gamma_factor):
+        if not isinstance(gamma_factor, float):
             gamma_factor = gamma_factor[..., np.newaxis]
         means = gamma_factor * means
         # Propagate uncertainties:

--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -175,7 +175,9 @@ def executor_expectation_values(
         axis_positions_before_shots = -2 - np.arange(len(avg_axis))
         bool_array = np.moveaxis(bool_array, avg_axis, axis_positions_before_shots)
         # flatten into shots axis (preserve sizes of other axes, including bits axis):
-        bool_array = np.reshape(bool_array, (*bool_array.shape[:-2-len(avg_axis)], -1, bool_array.shape[-1]))
+        bool_array = np.reshape(
+            bool_array, (*bool_array.shape[: -2 - len(avg_axis)], -1, bool_array.shape[-1])
+        )
 
         # update others to match:
         num_shots_kept = np.sum(num_shots_kept, avg_axis)
@@ -212,7 +214,7 @@ def executor_expectation_values(
             gamma_factor = gamma_factor[..., np.newaxis]
         means = gamma_factor * means
         # Propagate uncertainties:
-        variances = (gamma_factor*standard_errs)**2
+        variances = (gamma_factor * standard_errs) ** 2
         # Move observable axis from end to front:
         mean_each_observable += np.moveaxis(means, -1, 0)
         var_each_observable += np.moveaxis(variances, -1, 0)

--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -385,8 +385,8 @@ def _bitarray_expectation_value(
     parities = (outcomes & mask_z).bitcount() % 2
 
     # Compute the coefficients of 0 and 1 components.
-    nulled_by_0_projector = np.logical_or.reduce((outcomes & mask_0).array, axis=-1)
-    nulled_by_1_projector = np.logical_or.reduce(((outcomes & mask_1) ^ mask_1).array, axis=-1)
+    nulled_by_0_projector = np.any((outcomes & mask_0).array, axis=-1)
+    nulled_by_1_projector = np.any(((outcomes & mask_1) ^ mask_1).array, axis=-1)
     coeffs_01 = ~np.logical_or(nulled_by_0_projector, nulled_by_1_projector)
 
     # Compute expectation values
@@ -406,7 +406,7 @@ def _bitarray_expectation_value(
 
     # Divide by total shots. May be less than nominal number in array if
     # we are postselecting via projector in observable terms:
-    shots = np.asarray(outcomes.num_shots) if shots is None else shots[..., np.newaxis]
+    shots = outcomes.num_shots if shots is None else shots[..., np.newaxis]
 
     # Edge case of counts dict containing outcomes but with total shots, eg {"0": 0}.
     with np.errstate(divide="ignore"):

--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -109,7 +109,7 @@ def executor_expectation_values(
         if postselect_mask is not None:
             postselect_mask = postselect_mask.reshape((1, *postselect_mask.shape))
         meas_basis_axis = 0
-        avg_axis = tuple(a + 1 for a in avg_axis)
+        avg_ax = tuple(a + 1 for a in avg_ax)
     elif meas_basis_axis < 0:
         raise ValueError("meas_basis_axis must be nonnegative.")
 
@@ -163,26 +163,26 @@ def executor_expectation_values(
         # For PEC, we will need to multiply by gamma later when computing expectation values.
         if gamma_factor is None:
             # If gamma not provided, estimate it empirically, for each requested expectation value:
-            num_minus = np.count_nonzero(net_signs, axis=avg_axis)
-            num_plus = np.count_nonzero(~net_signs, axis=avg_axis)
+            num_minus = np.count_nonzero(net_signs, axis=avg_ax)
+            num_plus = np.count_nonzero(~net_signs, axis=avg_ax)
             num_twirls = num_plus + num_minus
             gamma_factor = num_twirls / (num_plus - num_minus)
     elif gamma_factor is None:
         gamma_factor = 1
 
     ##### If other axes are to be averaged over, do so by first absorbing them into the shots axis:
-    if avg_axis:
-        # move avg_axis just before shots axis (just before axis -2):
-        axis_positions_before_shots = -2 - np.arange(len(avg_axis))
-        bool_array = np.moveaxis(bool_array, avg_axis, axis_positions_before_shots)
+    if avg_ax:
+        # move avg_ax just before shots axis (just before axis -2):
+        axis_positions_before_shots = -2 - np.arange(len(avg_ax))
+        bool_array = np.moveaxis(bool_array, avg_ax, axis_positions_before_shots)
         # flatten into shots axis (preserve sizes of other axes, including bits axis):
         bool_array = np.reshape(
-            bool_array, (*bool_array.shape[: -2 - len(avg_axis)], -1, bool_array.shape[-1])
+            bool_array, (*bool_array.shape[: -2 - len(avg_ax)], -1, bool_array.shape[-1])
         )
 
         # update others to match:
-        num_shots_kept = np.sum(num_shots_kept, avg_axis)
-        meas_basis_axis -= np.sum(np.asarray(avg_axis) < meas_basis_axis)
+        num_shots_kept = np.sum(num_shots_kept, avg_ax)
+        meas_basis_axis -= np.sum(np.asarray(avg_ax) < meas_basis_axis)
 
     ##### ACCUMULATE CONTRIBUTIONS FROM EACH MEAS BASIS:
     barray = BitArray.from_bool_array(bool_array, "little")

--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -162,10 +162,7 @@ def executor_expectation_values(
         # For PEC, we will need to multiply by gamma later when computing expectation values.
         if gamma_factor is None:
             # If gamma not provided, estimate it empirically, for each requested expectation value:
-            num_minus = np.count_nonzero(net_signs, axis=avg_axis)
-            num_plus = np.count_nonzero(~net_signs, axis=avg_axis)
-            num_twirls = num_plus + num_minus
-            gamma_factor = num_twirls / (num_plus - num_minus)
+            gamma_factor = 1 / (1 - 2 * np.mean(net_signs, axis=avg_axis))
     elif gamma_factor is None:
         gamma_factor = 1.0
 

--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -93,8 +93,7 @@ def executor_expectation_values(
         ValueError if the number of entries in `basis_dict` does not equal the length of `bool_array` along `meas_basis_axis`.
     """
     ##### VALIDATE INPUTS:
-    avg_ax: tuple[int] = _validate_avg_axis(avg_axis, len(bool_array.shape))
-    # change name to make linter happy
+    avg_axis = _validate_avg_axis(avg_axis, len(bool_array.shape))
 
     if meas_basis_axis is None:
         if len(basis_dict) != 1:
@@ -109,7 +108,7 @@ def executor_expectation_values(
         if postselect_mask is not None:
             postselect_mask = postselect_mask.reshape((1, *postselect_mask.shape))
         meas_basis_axis = 0
-        avg_ax = tuple(a + 1 for a in avg_ax)
+        avg_axis = tuple(a + 1 for a in avg_axis)
     elif meas_basis_axis < 0:
         raise ValueError("meas_basis_axis must be nonnegative.")
 
@@ -163,26 +162,26 @@ def executor_expectation_values(
         # For PEC, we will need to multiply by gamma later when computing expectation values.
         if gamma_factor is None:
             # If gamma not provided, estimate it empirically, for each requested expectation value:
-            num_minus = np.count_nonzero(net_signs, axis=avg_ax)
-            num_plus = np.count_nonzero(~net_signs, axis=avg_ax)
+            num_minus = np.count_nonzero(net_signs, axis=avg_axis)
+            num_plus = np.count_nonzero(~net_signs, axis=avg_axis)
             num_twirls = num_plus + num_minus
             gamma_factor = num_twirls / (num_plus - num_minus)
     elif gamma_factor is None:
-        gamma_factor = 1
+        gamma_factor = 1.
 
     ##### If other axes are to be averaged over, do so by first absorbing them into the shots axis:
-    if avg_ax:
-        # move avg_ax just before shots axis (just before axis -2):
-        axis_positions_before_shots = -2 - np.arange(len(avg_ax))
-        bool_array = np.moveaxis(bool_array, avg_ax, axis_positions_before_shots)
+    if avg_axis:
+        # move avg_axis just before shots axis (just before axis -2):
+        axis_positions_before_shots = -2 - np.arange(len(avg_axis))
+        bool_array = np.moveaxis(bool_array, avg_axis, axis_positions_before_shots)
         # flatten into shots axis (preserve sizes of other axes, including bits axis):
         bool_array = np.reshape(
-            bool_array, (*bool_array.shape[: -2 - len(avg_ax)], -1, bool_array.shape[-1])
+            bool_array, (*bool_array.shape[: -2 - len(avg_axis)], -1, bool_array.shape[-1])
         )
 
         # update others to match:
-        num_shots_kept = np.sum(num_shots_kept, avg_ax)
-        meas_basis_axis -= np.sum(np.asarray(avg_ax) < meas_basis_axis)
+        num_shots_kept = np.sum(num_shots_kept, avg_axis)
+        meas_basis_axis -= int(np.sum(np.asarray(avg_axis) < meas_basis_axis))
 
     ##### ACCUMULATE CONTRIBUTIONS FROM EACH MEAS BASIS:
     barray = BitArray.from_bool_array(bool_array, "little")

--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -386,7 +386,7 @@ def _bitarray_expectation_value(
 
     # Compute the coefficients of 0 and 1 components.
     nulled_by_0_projector = np.any((outcomes & mask_0).array, axis=-1)
-    nulled_by_1_projector = np.any(((outcomes & mask_1) ^ mask_1).array, axis=-1)
+    nulled_by_1_projector = np.any((~outcomes & mask_1).array, axis=-1)
     coeffs_01 = ~np.logical_or(nulled_by_0_projector, nulled_by_1_projector)
 
     # Compute expectation values


### PR DESCRIPTION
Main changes are in the first commit. Slightly edited version of its commit message:

> Previously, first averaged over shots, then averaged over twirls (or other specified axes).
> 
> This was complicated by the need to keep track of how many shots were accepted by postselection in order to propagate uncertainty properly later when averaging over twirls. Also by the need to keep track of PEC signs (`pauli_signs`).
> 
> Now, we first flatten `avg_axis` (typically the twirl axis) into the shots axis, then do all averaging + postselection at once. This avoids needing to work with `weights`. This should also avoid the situation where postselection rejects all shots on a single twirl, resulting in `nan` for the average of all twirls (particularly problematic when approaching the theoretically-optimal case of 1 shot per twirl).