### PR TITLE
Docstring suggestions

### DIFF
--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -18,7 +18,7 @@ from collections.abc import Sequence
 
 import numpy as np
 from qiskit.primitives import BitArray
-from qiskit.quantum_info import Pauli, PauliList, SparseObservable, SparsePauliOp
+from qiskit.quantum_info import Pauli, SparseObservable, SparsePauliOp
 
 from qiskit_addon_utils.exp_vals.measurement_bases import find_measure_basis_to_observable_mapping
 
@@ -28,7 +28,7 @@ def executor_expectation_values(
     # rename them without breaking API
     bool_array: np.ndarray[tuple[int, ...], np.dtype[np.bool_]],
     basis_mapping: dict[Pauli, list[SparsePauliOp | None]]
-    | tuple[Sequence[SparsePauliOp], Sequence[str | PauliList]],
+    | tuple[Sequence[SparsePauliOp], Sequence[str | Pauli]],
     /,
     # positional or keyword arguments
     meas_basis_axis: int | None = None,
@@ -42,63 +42,62 @@ def executor_expectation_values(
     gamma_factor: float | None = None,
     rescale_factors: Sequence[Sequence[Sequence[float]]] | None = None,
 ):
-    """Computes expectation values from boolean data and metadata, aiming for compatibility with the components of a result from ``Executor`` in ``qiskit_ibm_runtime`` .
+    """Computes expectation values from shot data from ``qiskit_ibm_runtime.Executor`` and metadata.
 
-    Uses data in `bool_array`, acquired with measurement bases as ordered in keys of `basis_dict`, to compute observables encoded in values of `basis_dict`.
+    Uses data in ``bool_array``, acquired with measurement bases as ordered in keys of ``basis_dict``, to compute observables encoded in values of ``basis_dict``.
 
-    Optionally allows averaging over additional axes of `bool_array`, as when twirling.
+    Optionally allows averaging over additional axes of ``bool_array``, as when twirling.
 
     Optionally supports measurement twirling, PEC, and postselection.
 
     Args:
         bool_array: Boolean array, presumably representing data from measured qubits.
             The last two axes are the number of shots and number of classical bits, respectively.
-            The least significant bit is assumed to be at index `0` of the bits axis.
-            If `meas_basis_axis` is given, that axis of `bool_array` indexes the measurement bases, with length `len(basis_mapping)`.
-        basis_mapping: This dict encodes how the data in `bool_array` should be used to estimate the desired list of Pauli observables.
-            The ith key is a measurement basis assumed to correspond to the ith slice of `bool_array` along the `meas_basis_axis` axis.
-            Each dict value is a list of length equal to the number of desired observables.
-            The jth element of this list is a `SparsePauliOp` assumed to be compatible (qubit-wise commuting) with the measurement-basis key.
-            In place of a `SparsePauliOp`, `None` may be used to represent the zero operator, when a basis is not used to compute an observable.
-            The jth observable is defined as the sum of the jth element of each dict value (contribution from each meas basis).
-            - Note the order of dict entries is relied on here for indexing; the dict keys are never used.
-            - Assumes each Pauli term (in dict values) is compatible with each measurement basis (in keys).
-            - Assumes each term in each observable appears for exactly one basis.
-            Alternatively, a tuple of (observables, measurement_bases) can be passed. A mapping between the measurement bases and the observables
-            will be computed. For each term in each observable, the first qubit-wise commuting basis from the bases list will be used as its measurement basis.
-            If no qubit-wise commuting basis is found for at least one of the terms in one of the observables, an error will be raised.
-            The number of bases in `measurement_bases` must be the same as the length of the meas_basis_axis in bool_array, and the order must match the order in bool_array.
-        meas_basis_axis: Axis of bool_array that indexes measurement bases. Ordering must match ordering in `basis_mapping`. If `None`,
-            then `len(basis_mapping)` must be 1, and `bool_array` is assumed to correspond to the only measurement basis.
+            The least significant bit is assumed to be at index ``0`` of the bits axis.
+            If ``meas_basis_axis`` is given, that axis of ``bool_array`` indexes the measurement bases, with length ``len(basis_mapping)``.
+        basis_mapping: The Pauli observables and associated bases which were measured. Can be a ``tuple``, ``(observables, msmt_bases)``, or a
+            ``dict``, ``{basis: commuting_observables}``.
+
+            - **tuple**: A length-2 tuple containing ``(observables, msmt_bases)``, where ``observables`` is a sequence of ``SparsePauliOp`` instances for
+              which individual expectation values should be calculated, and ``msmt_bases`` is a sequence of Pauli observables. The ``i``th Pauli in
+              ``msmt_bases`` is expected to correspond to the ``i``th slice of ``bool_array`` along the ``meas_basis_axis``.
+
+            - **dict**: The ``i``th key is a measurement basis assumed to correspond to the ``i``th slice of ``bool_array`` along the ``meas_basis_axis`` axis.
+              The values are lists of observables (``SparsePauliOp``) with length equal to the number of observables. ``None`` values are used
+              when an observable does not qubit-wise commute with the basis. This method assumes each observable appears only once in the values, even if it
+              commutes with more than one basis.
+
+        meas_basis_axis: Axis of bool_array that indexes measurement bases. Ordering must match ordering in ``basis_mapping``. If ``None``,
+            then ``len(basis_mapping)`` must be ``1``, and ``bool_array`` is assumed to correspond to the only measurement basis.
         avg_axis: Optional axis or axes of bool_array to average over when computing expectation values. Usually this is the "twirling" axis.
-            Must be nonnegative. (The shots axis, assumed to be at index -2 in the boolean array, is always averaged over).
+            Must be nonnegative. (The shots axis, assumed to be at index ``-2`` in the boolean array, is always averaged over).
         measurement_flips: Optional boolean array used with measurement twirling. Indicates which bits were acquired with measurements preceded by bit-flip gates.
-            Data processing will use the result of `xor`ing this array with `bool_array`. Must be same shape as `bool_array`.
-        pauli_signs: Optional boolean array used with probabilistic error cancellation (PEC). Final axis is assumed to index all noisy boxes in circuit. Value of `True` indicates an overall sign of `-1` should be associated with the noisy box, typically because an odd number of inverse-noise errors were inserted in that box for the specified circuit randomization. The final axis is immediately collapsed as a sum mod 2 to obtain the overall sign associated with each circuit randomization.
-            Remaining shape must be `pauli_signs.shape[:-1] == bool_array.shape[:-2]`. Note this array does not have a shots axis.
-        postselect_mask: Optional boolean array used for postselection. `True` (`False`) indicates a shot accepted (rejected) by postselection.
-            Shape must be `bool_array.shape[:-1]`.
-        gamma_factor: Rescaling factor gamma to be applied to PEC mitigated expectation values. If `None`, rescaling factors will be computed as the
-            number of positive samples minus the number of negative samples, computed as `1/(np.sum(~pauli_signs, axis=avg_axis) - np.sum(pauli_signs, axis=avg_axis))`.
+            Data processing will use the result of XOR`ing this array with ``bool_array``. Must be same shape as ``bool_array``.
+        pauli_signs: Optional boolean array used with probabilistic error cancellation (PEC). Final axis is assumed to index all noisy boxes in circuit. Value of ``True`` indicates an overall sign of ``-1`` should be associated with the noisy box, typically because an odd number of inverse-noise errors were inserted in that box for the specified circuit randomization. The final axis is immediately collapsed as a sum mod 2 to obtain the overall sign associated with each circuit randomization.
+            Remaining shape must be ``pauli_signs.shape[:-1] == bool_array.shape[:-2]``. Note this array does not have a shots axis.
+        postselect_mask: Optional boolean array used for postselection. ``True`` (``False``) indicates a shot accepted (rejected) by postselection.
+            Shape must be ``bool_array.shape[:-1]``.
+        gamma_factor: Rescaling factor gamma to be applied to PEC mitigated expectation values. If ``None``, rescaling factors will be computed as the
+            number of positive samples minus the number of negative samples, computed as ``1/(np.sum(~pauli_signs, axis=avg_axis) - np.sum(pauli_signs, axis=avg_axis))``.
             This can fail due to division by zero if there are an equal number of positive and negative samples. Also note this rescales each expectation value
             by a different factor. (TODO: allow specifying an array of gamma values).
         rescale_factors: Scale factor for each Pauli term in each observable in each basis in the given ``basis_mapping``.
             Typically used for readout mitigation ("TREX") correction factors.
             Each item in the list corresponds to a different basis, and contains a list of lists of factors for each term in each observable related to that basis.
-            The order of the bases and the observables inside each basis should be the same as in `basis_mapping`.
-            For empty observables for some of the bases, keep an empty list. If `None`, scaling factor will not be applied.
+            The order of the bases and the observables inside each basis should be the same as in ``basis_mapping``.
+            For empty observables for some of the bases, keep an empty list. If ``None``, scaling factor will not be applied.
 
     Returns:
         A list of (exp. val, variance) 2-tuples, one for each desired observable.
 
         Note: Covariances between summed terms in each observable are not currently accounted for in the
-            returned variances. (TODO)
+            returned variances. # TODO
 
     Raises:
-        ValueError if `avg_axis` contains negative values.
-        ValueError if `meas_basis_axis` is `None` but `len(basis_mapping) != 1`.
-        ValueError if the number of entries in `basis_mapping` does not equal the length of `bool_array` along `meas_basis_axis`.
-        ValueError if the given measurement_basis can not cover all of the terms in al lof the observables.
+        ValueError: ``avg_axis`` contains negative values.
+        ValueError: ``meas_basis_axis`` is ``None`` but ``len(basis_mapping) != 1``.
+        ValueError: The number of entries in ``basis_mapping`` does not equal the length of ``bool_array`` along ``meas_basis_axis``.
+        ValueError if the given measurement_basis can not cover all of the terms in all of the observables.
     """
     ##### VALIDATE INPUTS:
     avg_axis = _validate_avg_axis(avg_axis, len(bool_array.shape))

--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -59,10 +59,10 @@ def executor_expectation_values(
             ``dict``, ``{basis: commuting_observables}``.
 
             - **tuple**: A length-2 tuple containing ``(observables, msmt_bases)``, where ``observables`` is a sequence of ``SparsePauliOp`` instances for
-              which individual expectation values should be calculated, and ``msmt_bases`` is a sequence of Pauli observables. The ``i``th Pauli in
-              ``msmt_bases`` is expected to correspond to the ``i``th slice of ``bool_array`` along the ``meas_basis_axis``.
+              which individual expectation values should be calculated, and ``msmt_bases`` is a sequence of Pauli observables. The ``i`` th Pauli in
+              ``msmt_bases`` is expected to correspond to the ``i`` th slice of ``bool_array`` along the ``meas_basis_axis``.
 
-            - **dict**: The ``i``th key is a measurement basis assumed to correspond to the ``i``th slice of ``bool_array`` along the ``meas_basis_axis`` axis.
+            - **dict**: The ``i`` th key is a measurement basis assumed to correspond to the ``i`` th slice of ``bool_array`` along the ``meas_basis_axis`` axis.
               The values are lists of observables (``SparsePauliOp``) with length equal to the number of observables. ``None`` values are used
               when an observable does not qubit-wise commute with the basis. This method assumes each observable appears only once in the values, even if it
               commutes with more than one basis.
@@ -97,7 +97,7 @@ def executor_expectation_values(
         ValueError: ``avg_axis`` contains negative values.
         ValueError: ``meas_basis_axis`` is ``None`` but ``len(basis_mapping) != 1``.
         ValueError: The number of entries in ``basis_mapping`` does not equal the length of ``bool_array`` along ``meas_basis_axis``.
-        ValueError if the given measurement_basis can not cover all of the terms in all of the observables.
+        ValueError: An observable is not covered by the measurement bases.
     """
     ##### VALIDATE INPUTS:
     avg_axis = _validate_avg_axis(avg_axis, len(bool_array.shape))

--- a/qiskit_addon_utils/exp_vals/expectation_values.py
+++ b/qiskit_addon_utils/exp_vals/expectation_values.py
@@ -72,7 +72,7 @@ def executor_expectation_values(
         avg_axis: Optional axis or axes of bool_array to average over when computing expectation values. Usually this is the "twirling" axis.
             Must be nonnegative. (The shots axis, assumed to be at index ``-2`` in the boolean array, is always averaged over).
         measurement_flips: Optional boolean array used with measurement twirling. Indicates which bits were acquired with measurements preceded by bit-flip gates.
-            Data processing will use the result of XOR`ing this array with ``bool_array``. Must be same shape as ``bool_array``.
+            Data processing will use the result of XOR'ing this array with ``bool_array``. Must be same shape as ``bool_array``.
         pauli_signs: Optional boolean array used with probabilistic error cancellation (PEC). Final axis is assumed to index all noisy boxes in circuit. Value of ``True`` indicates an overall sign of ``-1`` should be associated with the noisy box, typically because an odd number of inverse-noise errors were inserted in that box for the specified circuit randomization. The final axis is immediately collapsed as a sum mod 2 to obtain the overall sign associated with each circuit randomization.
             Remaining shape must be ``pauli_signs.shape[:-1] == bool_array.shape[:-2]``. Note this array does not have a shots axis.
         postselect_mask: Optional boolean array used for postselection. ``True`` (``False``) indicates a shot accepted (rejected) by postselection.


### PR DESCRIPTION
<img width="952" height="281" alt="Screenshot 2026-04-20 at 2 54 30 PM" src="https://github.com/user-attachments/assets/73ffb5bc-5f7f-4a77-8d8a-51c7e43cdb4a" />


This branch PR adds double ticks where needed to the expval function, reworks the `basis_mapping` input docstring to be a little cleaner, and fixes a type hint I suspect is wrong