### PR TITLE
Migrate to PEP 735 dependency groups

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -33,7 +33,7 @@ jobs:
           python -m pip install --upgrade pip
       - name: Install tools from pypi
         run: |
-          python -m pip install tox build extremal-python-dependencies~=0.0.5
+          python -m pip install tox build extremal-python-dependencies~=0.2.0
       - name: Build Qiskit SDK development wheel
         run: |
           git clone https://github.com/Qiskit/qiskit

--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -33,7 +33,7 @@ jobs:
           python -m pip install --upgrade pip
       - name: Install tools from pypi
         run: |
-          python -m pip install tox build git+https://github.com/IBM/extremal-python-dependencies.git@fix-depgroup-replacements
+          python -m pip install tox build extremal-python-dependencies~=0.2.1
       - name: Build Qiskit SDK development wheel
         run: |
           git clone https://github.com/Qiskit/qiskit

--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -33,7 +33,7 @@ jobs:
           python -m pip install --upgrade pip
       - name: Install tools from pypi
         run: |
-          python -m pip install tox build extremal-python-dependencies~=0.2.0
+          python -m pip install tox build git+https://github.com/IBM/extremal-python-dependencies.git@fix-depgroup-replacements
       - name: Build Qiskit SDK development wheel
         run: |
           git clone https://github.com/Qiskit/qiskit

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          python -m pip install extremal-python-dependencies~=0.2.0
+          python -m pip install extremal-python-dependencies~=0.2.1
           pip install "tox==$(extremal-python-dependencies get-tox-minversion)"
           extremal-python-dependencies pin-dependencies-to-minimum --inplace
       - name: Test using tox environment

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          python -m pip install extremal-python-dependencies~=0.0.5
+          python -m pip install extremal-python-dependencies~=0.2.0
           pip install "tox==$(extremal-python-dependencies get-tox-minversion)"
           extremal-python-dependencies pin-dependencies-to-minimum --inplace
       - name: Test using tox environment

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,26 +32,31 @@ dependencies = [
     "qiskit>=2.2, <3",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 dev = [
-    "qiskit-addon-utils[test,doctest,nbtest,lint,docs]",
-    "tox>=4.4.3",
+    {include-group = "test"},
+    {include-group = "doctest"},
+    {include-group = "nbtest"},
+    {include-group = "lint"},
+    {include-group = "docs"},
+    "tox>=4.22.0",
 ]
 basetest = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
 ]
 test = [
-    "qiskit-addon-utils[basetest]",
+    {include-group = "basetest"},
     "qiskit-qasm3-import>=0.5.0",
     "samplomatic>=0.13",
 ]
 doctest = [
-    "qiskit-addon-utils[basetest,notebook-dependencies]",
+    {include-group = "basetest"},
+    {include-group = "notebook-dependencies"},
     "pytest-doctestplus>=1.3.0",
 ]
 nbtest = [
-    "qiskit-addon-utils[basetest]",
+    {include-group = "basetest"},
     "nbmake>=1.5.0",
 ]
 style = [
@@ -59,7 +64,7 @@ style = [
     "nbqa>=1.8.5",
 ]
 lint = [
-    "qiskit-addon-utils[style]",
+    {include-group = "style"},
     "pylint==4.0.5",
     "mypy==1.20.0",
     "reno>=4.1",
@@ -73,7 +78,7 @@ notebook-dependencies = [
     "pylatexenc",
 ]
 docs = [
-    "qiskit-addon-utils[doctest]",
+    {include-group = "doctest"},
     "qiskit-sphinx-theme~=2.0.0",
     "jupyter-sphinx",
     "sphinx-design",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-minversion = 4.4.3
+minversion = 4.22.0
 envlist = py{310,311,312,313}{,-notebook}, lint, coverage, docs, doctest
 isolated_build = True
 
@@ -7,13 +7,13 @@ isolated_build = True
 package = wheel
 wheel_build_env = .pkg
 parallel_show_output = True
-extras =
+dependency_groups =
   test
 commands =
   pytest {posargs}
 
 [testenv:style]
-extras =
+dependency_groups =
   style
 commands =
   ruff format qiskit_addon_utils/ docs/ test/
@@ -25,7 +25,7 @@ image-tester-commit = 7ae965ccf21c39e5170334ec7f4882756883860a
 deps =
   git+https://github.com/Qiskit/documentation.git@{[testenv:lint]image-tester-commit}\#egg=sphinx-alt-text-validator&subdirectory=scripts/image-tester
 basepython = python3.10
-extras =
+dependency_groups =
   lint
 commands =
   ruff format --check qiskit_addon_utils/ docs/ test/
@@ -39,14 +39,14 @@ commands =
   reno lint
 
 [testenv:{,py-,py3-,py310-,py311-,py312-,py313-}notebook]
-extras =
+dependency_groups =
   nbtest
   notebook-dependencies
 commands =
   pytest --nbmake --nbmake-timeout=3000 {posargs} docs/
 
 [testenv:{,py-,py3-,py310-,py311-,py312-,py313-}doctest]
-extras =
+dependency_groups =
   test
   doctest
 commands =
@@ -56,7 +56,7 @@ commands =
 basepython = python3.11
 deps =
   coverage>=7.4.1
-extras =
+dependency_groups =
   test
   doctest
 commands =
@@ -64,7 +64,7 @@ commands =
 
 [testenv:docs]
 basepython = python3.10
-extras =
+dependency_groups =
   docs
 commands =
   sphinx-build -j auto -W -T --keep-going -b html {posargs} {toxinidir}/docs/ {toxinidir}/docs/_build/html


### PR DESCRIPTION
More information at https://packaging.python.org/en/latest/specifications/dependency-groups/

This also bumps the tox version to 4.22, the first version that supports dependency groups.