### PR TITLE
Use coverage module for lcov report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,7 @@ jobs:
           tox -e coverage
       - name: Convert to lcov
         if: always()
-        run: coverage3 lcov -o coveralls.lcov
+        run: python -m coverage lcov -o coveralls.lcov
       - name: Upload report to Coveralls
         if: always()
         uses: coverallsapp/github-action@v2


### PR DESCRIPTION
Replaced the deprecated `coverage3` entry point in the coverage workflow with `python -m coverage lcov`, keeping the same `coveralls.lcov` output consumed by the Coveralls upload step.

- Closes #197 