### PR TITLE
Loosen pin on extremal-python-dependencies

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -33,7 +33,7 @@ jobs:
           python -m pip install --upgrade pip
       - name: Install tools from pypi
         run: |
-          python -m pip install tox build extremal-python-dependencies~=0.0.5
+          python -m pip install tox build 'extremal-python-dependencies<2'
       - name: Build Qiskit SDK development wheel
         run: |
           git clone https://github.com/Qiskit/qiskit

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -30,7 +30,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          python -m pip install extremal-python-dependencies~=0.0.5
+          python -m pip install 'extremal-python-dependencies<2'
           pip install "tox==$(extremal-python-dependencies get-tox-minversion)"
           extremal-python-dependencies pin-dependencies-to-minimum --inplace
       - name: Test using tox environment


### PR DESCRIPTION
Now that extremal-python-dependencies 1.0.0 has been released, we can loosen the pin to allow for the latest release before major version 2, as it follows semantic versioning.