### PR TITLE
Update docs.yml: re-deploy docs when tag is pushed

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -61,7 +61,7 @@ jobs:
 
   deploy:
     name: deploy docs
-    if: ${{ github.ref == 'refs/heads/stable/0.4' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/stable/0.4' }}
     needs: build
     permissions:
       pages: write


### PR DESCRIPTION
This PR changes the doc workflow to re-deploy when a (release) tag is pushed. This way, the reno release notes will reference the release once the workflow is complete. Previously, it required either manually re-running the workflow or pushing another commit to the release branch.