### PR TITLE
Set `warn_unused_ignores = true` in mypy config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ python_version = "3.10"
 show_error_codes = true
 warn_return_any = true
 warn_unused_configs = true
+warn_unused_ignores = true
 ignore_missing_imports = true
 
 [tool.pylint.main]


### PR DESCRIPTION
It seems like a good idea to propagate https://github.com/Qiskit/qiskit-fermions/pull/189 across addons in order to remove outdated ignore comments. This repo will be a good starting point since we typically use it as a basis for new packages.