### PR TITLE
Allow `generate_xyz_hamiltonian` to accept arbitrary coefficient values

### DIFF
--- a/qiskit_addon_utils/problem_generators/generate_xyz_hamiltonian.py
+++ b/qiskit_addon_utils/problem_generators/generate_xyz_hamiltonian.py
@@ -138,14 +138,10 @@ def generate_xyz_hamiltonian(
         ValueError: The external magnetic field must be specified by a length-3 sequence of floating
             point values.
     """
-    if len(coupling_constants) != 3:
-        raise ValueError(
-            "Coupling constants must be specified by a length-3 sequence of floating point values."
-        )
-    if len(ext_magnetic_field) != 3:
-        raise ValueError(
-            "External magnetic field must be specified by a length-3 sequence of floating point values."
-        )
+
+    _validate_xyz_input(coupling_constants, name="Coupling constants")
+    _validate_xyz_input(ext_magnetic_field, name="External magnetic field") 
+    
     if coloring is None:
         # Specify the coupling as an undirected rx.PyGraph so we can color the edges
         undirected_graph = _make_undirected_graph(coupling)
@@ -157,6 +153,7 @@ def generate_xyz_hamiltonian(
     # Generate Hamiltonian
     num_qubits = coupling.size() if isinstance(coupling, CouplingMap) else coupling.num_nodes()
 
+    # Normalize the coupling constants and magnetic field values to a per-edge and per-qubit mapping
     edge_couplings = _normalize_coupling_constants(coupling_constants, colored_edges)
     site_fields = _normalize_ext_magnetic_field(ext_magnetic_field, num_qubits)
 
@@ -242,12 +239,24 @@ def _make_undirected_graph(
     return undirected_graph
 
 
+def _validate_xyz_input(value: float | Sequence[float] | dict, *, name: str) -> None:
+    """Validate top-level scalar/sequence inputs before normalization."""
+    if isinstance(value, dict):
+        return
+
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        if len(value) != 3:
+            raise ValueError(
+                f"{name} must be specified by a length-3 sequence of floating point values."
+            )
+
 def _normalize_xyz_triplet(
     value: float | Sequence[float],
     *,
     name: str,
 ) -> tuple[float, float, float]:
     """Normalize a scalar or 3-element sequence to a length-3 tuple."""
+    # If the value is a scalar, return a tuple with the same value repeated three times.
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
         if len(value) != 3:
             raise ValueError(f"{name} must be a scalar or length-3 sequence of floats.")
@@ -257,6 +266,7 @@ def _normalize_xyz_triplet(
 
 def _normalize_edge_key(edge: tuple[int, int]) -> tuple[int, int]:
     """Canonicalize an undirected edge key so (i, j) and (j, i) match."""
+    # Validate the edge key is a tuple of two integers
     if (
         not isinstance(edge, tuple)
         or len(edge) != 2
@@ -267,17 +277,26 @@ def _normalize_edge_key(edge: tuple[int, int]) -> tuple[int, int]:
 
 
 def _normalize_coupling_constants(
-    coupling_constants: float | Sequence[float] | dict[tuple[int, int], float | Sequence[float]],
-    colored_edges: list[tuple[tuple[int, int], int]],
-) -> dict[tuple[int, int], tuple[float, float, float]]:
-    """Return a per-edge (Jxx, Jyy, Jzz) mapping for every colored edge."""
+    coupling_constants,
+    colored_edges,
+):
     if isinstance(coupling_constants, dict):
-        normalized: dict[tuple[int, int], tuple[float, float, float]] = {}
+        normalized = {}
         for edge, value in coupling_constants.items():
-            normalized[_normalize_edge_key(edge)] = _normalize_xyz_triplet(
-                value, name="coupling_constants"
-            )
-        edge_map: dict[tuple[int, int], tuple[float, float, float]] = {}
+            canonical_edge = _normalize_edge_key(edge)
+            triplet = _normalize_xyz_triplet(value, name="coupling_constants")
+
+            if canonical_edge in normalized:
+                if normalized[canonical_edge] != triplet:
+                    raise ValueError(
+                        f"coupling_constants contains conflicting values for edge {canonical_edge}."
+                    )
+                # same value -> harmless duplicate, keep the existing entry
+                continue
+
+            normalized[canonical_edge] = triplet
+
+        edge_map = {}
         for edge, _ in colored_edges:
             edge_map[edge] = normalized.get(_normalize_edge_key(edge), (0.0, 0.0, 0.0))
         return edge_map

--- a/qiskit_addon_utils/problem_generators/generate_xyz_hamiltonian.py
+++ b/qiskit_addon_utils/problem_generators/generate_xyz_hamiltonian.py
@@ -138,10 +138,11 @@ def generate_xyz_hamiltonian(
         ValueError: The external magnetic field must be specified by a length-3 sequence of floating
             point values.
     """
-
+    # Validate inputs
     _validate_xyz_input(coupling_constants, name="Coupling constants")
-    _validate_xyz_input(ext_magnetic_field, name="External magnetic field") 
-    
+    _validate_xyz_input(ext_magnetic_field, name="External magnetic field")
+    _validate_edge_dict_keys(coupling_constants)
+
     if coloring is None:
         # Specify the coupling as an undirected rx.PyGraph so we can color the edges
         undirected_graph = _make_undirected_graph(coupling)
@@ -244,11 +245,22 @@ def _validate_xyz_input(value: float | Sequence[float] | dict, *, name: str) -> 
     if isinstance(value, dict):
         return
 
-    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
-        if len(value) != 3:
-            raise ValueError(
-                f"{name} must be specified by a length-3 sequence of floating point values."
-            )
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)) and len(value) != 3:
+        raise ValueError(
+            f"{name} must be specified by a length-3 sequence of floating point values."
+        )
+
+
+def _validate_edge_dict_keys(
+    coupling_constants: dict[tuple[int, int], float | Sequence[float]],
+) -> None:
+    """Validate that dict-based edge couplings use valid edge keys."""
+    if not isinstance(coupling_constants, dict):
+        return
+
+    for edge in coupling_constants:
+        _normalize_edge_key(edge)
+
 
 def _normalize_xyz_triplet(
     value: float | Sequence[float],

--- a/qiskit_addon_utils/problem_generators/generate_xyz_hamiltonian.py
+++ b/qiskit_addon_utils/problem_generators/generate_xyz_hamiltonian.py
@@ -133,10 +133,11 @@ def generate_xyz_hamiltonian(
         corresponds to the node in index ``i`` on the coupling map.
 
     Raises:
-        ValueError: The coupling constants must be specified by a length-3 sequence of floating
-            point values.
-        ValueError: The external magnetic field must be specified by a length-3 sequence of floating
-            point values.
+        ValueError: Coupling constants must be a scalar or length-3 sequence of floating point values.
+        ValueError: External magnetic field must be a scalar or length-3 sequence of floating point values.
+        ValueError: Edge keys must be tuples of two integer qubit indices.
+        ValueError: Coupling constants contains conflicting values for an edge.
+        ValueError: Magnetic field keys must be integer qubit indices.
     """
     # Validate inputs
     _validate_xyz_input(coupling_constants, name="Coupling constants")
@@ -247,7 +248,7 @@ def _validate_xyz_input(value: float | Sequence[float] | dict, *, name: str) -> 
 
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes)) and len(value) != 3:
         raise ValueError(
-            f"{name} must be specified by a length-3 sequence of floating point values."
+            f"{name} must be specified by a length-3 sequence of scalar or floating point values."
         )
 
 
@@ -298,7 +299,7 @@ def _normalize_coupling_constants(
             if canonical_edge in normalized:
                 if normalized[canonical_edge] != triplet:
                     raise ValueError(
-                        f"coupling_constants contains conflicting values for edge {canonical_edge}."
+                        f"Coupling_constants contains conflicting values for edge {canonical_edge}."
                     )
                 continue
 

--- a/qiskit_addon_utils/problem_generators/generate_xyz_hamiltonian.py
+++ b/qiskit_addon_utils/problem_generators/generate_xyz_hamiltonian.py
@@ -56,8 +56,16 @@ class PauliOrderStrategy(Enum):
 def generate_xyz_hamiltonian(
     coupling: CouplingMap | rx.PyGraph | rx.PyDiGraph,
     *,
-    coupling_constants: Sequence[float] = (1.0, 1.0, 1.0),
-    ext_magnetic_field: Sequence[float] = (0.0, 0.0, 0.0),
+    coupling_constants: float | Sequence[float] | dict[tuple[int, int], float | Sequence[float]] = (
+        1.0,
+        1.0,
+        1.0,
+    ),
+    ext_magnetic_field: float | Sequence[float] | dict[int, float | Sequence[float]] = (
+        0.0,
+        0.0,
+        0.0,
+    ),
     pauli_order_strategy: PauliOrderStrategy = PauliOrderStrategy.ColorThenInteraction,
     coloring: dict[tuple[int, int], int] | None = None,
 ) -> SparsePauliOp:
@@ -107,8 +115,11 @@ def generate_xyz_hamiltonian(
             will be ignored, and parallel edges will be treated as a single edge during generation
             of the operator.
         coupling_constants: The real-valued coupling constants, :math:`J_i`, in each Cartesian axis.
-        ext_magnetic_field: The coefficients, :math:`h_i`, representing a magnetic field along each
-            Cartesian axis.
+            May be a single scalar, a length-3 sequence, or a dict mapping edge tuples
+            `(i, j)` to scalars or length-3 sequences.
+        ext_magnetic_field: The coefficients, :math:`h_i`, representing a magnetic field
+            along each Cartesian axis. May be a single scalar, a length-3 sequence,
+            or a dict mapping qubit indices to scalars or length-3 sequences.
         pauli_order_strategy: Indicates the iteration strategy in which the Pauli terms will be
             generated. See :class:`.PauliOrderStrategy` for more details.
         coloring: An optional dictionary encoding the graph coloring that is used to sort the
@@ -135,7 +146,6 @@ def generate_xyz_hamiltonian(
         raise ValueError(
             "External magnetic field must be specified by a length-3 sequence of floating point values."
         )
-
     if coloring is None:
         # Specify the coupling as an undirected rx.PyGraph so we can color the edges
         undirected_graph = _make_undirected_graph(coupling)
@@ -146,36 +156,50 @@ def generate_xyz_hamiltonian(
 
     # Generate Hamiltonian
     num_qubits = coupling.size() if isinstance(coupling, CouplingMap) else coupling.num_nodes()
+
+    edge_couplings = _normalize_coupling_constants(coupling_constants, colored_edges)
+    site_fields = _normalize_ext_magnetic_field(ext_magnetic_field, num_qubits)
+
     ham_sparse_list = []
     if pauli_order_strategy == PauliOrderStrategy.ColorThenInteraction:
         for edge, _ in colored_edges:
-            for p, J in zip(("XX", "YY", "ZZ"), coupling_constants):
+            Jxx, Jyy, Jzz = edge_couplings[edge]
+            for p, J in zip(("XX", "YY", "ZZ"), (Jxx, Jyy, Jzz)):
                 if not np.isclose(J, 0.0):
                     ham_sparse_list.append((p, [edge[0], edge[1]], J))
         for qubit in range(num_qubits):
-            for p, h in zip("XYZ", ext_magnetic_field):
+            hx, hy, hz = site_fields[qubit]
+            for p, h in zip("XYZ", (hx, hy, hz)):
                 if not np.isclose(h, 0.0):
                     ham_sparse_list.append((p, [qubit], h))
     elif pauli_order_strategy == PauliOrderStrategy.InteractionThenColor:
-        for p, J in zip(("XX", "YY", "ZZ"), coupling_constants):
-            if not np.isclose(J, 0.0):
-                for edge, _ in colored_edges:
+        for p_index, p in enumerate(("XX", "YY", "ZZ")):
+            for edge, _ in colored_edges:
+                Jxx, Jyy, Jzz = edge_couplings[edge]
+                J = (Jxx, Jyy, Jzz)[p_index]
+                if not np.isclose(J, 0.0):
                     ham_sparse_list.append((p, [edge[0], edge[1]], J))
-        for p, h in zip("XYZ", ext_magnetic_field):
-            if not np.isclose(h, 0.0):
-                for qubit in range(num_qubits):
+        for p_index, p in enumerate("XYZ"):
+            for qubit in range(num_qubits):
+                hx, hy, hz = site_fields[qubit]
+                h = (hx, hy, hz)[p_index]
+                if not np.isclose(h, 0.0):
                     ham_sparse_list.append((p, [qubit], h))
     elif pauli_order_strategy == PauliOrderStrategy.InteractionThenColorZigZag:
         zig_zag_state = False
-        for p, J in zip(("XX", "YY", "ZZ"), coupling_constants):
-            if not np.isclose(J, 0.0):
-                edges = reversed(colored_edges) if zig_zag_state else iter(colored_edges)
-                zig_zag_state = not zig_zag_state
-                for edge, _ in edges:
+        for p_index, p in enumerate(("XX", "YY", "ZZ")):
+            edges = reversed(colored_edges) if zig_zag_state else colored_edges
+            zig_zag_state = not zig_zag_state
+            for edge, _ in edges:
+                Jxx, Jyy, Jzz = edge_couplings[edge]
+                J = (Jxx, Jyy, Jzz)[p_index]
+                if not np.isclose(J, 0.0):
                     ham_sparse_list.append((p, [edge[0], edge[1]], J))
-        for p, h in zip("XYZ", ext_magnetic_field):
-            if not np.isclose(h, 0.0):
-                for qubit in range(num_qubits):
+        for p_index, p in enumerate("XYZ"):
+            for qubit in range(num_qubits):
+                hx, hy, hz = site_fields[qubit]
+                h = (hx, hy, hz)[p_index]
+                if not np.isclose(h, 0.0):
                     ham_sparse_list.append((p, [qubit], h))
     else:  # pragma: no cover
         # NOTE: PauliOrderStrategy is an Enum so we cannot get here. Once Python 3.10 becomes the
@@ -216,3 +240,64 @@ def _make_undirected_graph(
                 undirected_edges.add(edge)
 
     return undirected_graph
+
+
+def _normalize_xyz_triplet(
+    value: float | Sequence[float],
+    *,
+    name: str,
+) -> tuple[float, float, float]:
+    """Normalize a scalar or 3-element sequence to a length-3 tuple."""
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        if len(value) != 3:
+            raise ValueError(f"{name} must be a scalar or length-3 sequence of floats.")
+        return (float(value[0]), float(value[1]), float(value[2]))
+    return (float(value), float(value), float(value))
+
+
+def _normalize_edge_key(edge: tuple[int, int]) -> tuple[int, int]:
+    """Canonicalize an undirected edge key so (i, j) and (j, i) match."""
+    if (
+        not isinstance(edge, tuple)
+        or len(edge) != 2
+        or not all(isinstance(idx, int) for idx in edge)
+    ):
+        raise ValueError("Edge keys must be tuples of two integer qubit indices.")
+    return tuple(sorted(edge))
+
+
+def _normalize_coupling_constants(
+    coupling_constants: float | Sequence[float] | dict[tuple[int, int], float | Sequence[float]],
+    colored_edges: list[tuple[tuple[int, int], int]],
+) -> dict[tuple[int, int], tuple[float, float, float]]:
+    """Return a per-edge (Jxx, Jyy, Jzz) mapping for every colored edge."""
+    if isinstance(coupling_constants, dict):
+        normalized: dict[tuple[int, int], tuple[float, float, float]] = {}
+        for edge, value in coupling_constants.items():
+            normalized[_normalize_edge_key(edge)] = _normalize_xyz_triplet(
+                value, name="coupling_constants"
+            )
+        edge_map: dict[tuple[int, int], tuple[float, float, float]] = {}
+        for edge, _ in colored_edges:
+            edge_map[edge] = normalized.get(_normalize_edge_key(edge), (0.0, 0.0, 0.0))
+        return edge_map
+
+    triple = _normalize_xyz_triplet(coupling_constants, name="coupling_constants")
+    return {edge: triple for edge, _ in colored_edges}
+
+
+def _normalize_ext_magnetic_field(
+    ext_magnetic_field: float | Sequence[float] | dict[int, float | Sequence[float]],
+    num_qubits: int,
+) -> dict[int, tuple[float, float, float]]:
+    """Return a per-qubit (hx, hy, hz) mapping for every qubit."""
+    if isinstance(ext_magnetic_field, dict):
+        normalized: dict[int, tuple[float, float, float]] = {}
+        for qubit, value in ext_magnetic_field.items():
+            if not isinstance(qubit, int):
+                raise ValueError("Magnetic field keys must be integer qubit indices.")
+            normalized[qubit] = _normalize_xyz_triplet(value, name="ext_magnetic_field")
+        return {qubit: normalized.get(qubit, (0.0, 0.0, 0.0)) for qubit in range(num_qubits)}
+
+    triple = _normalize_xyz_triplet(ext_magnetic_field, name="ext_magnetic_field")
+    return {qubit: triple for qubit in range(num_qubits)}

--- a/qiskit_addon_utils/problem_generators/generate_xyz_hamiltonian.py
+++ b/qiskit_addon_utils/problem_generators/generate_xyz_hamiltonian.py
@@ -267,8 +267,12 @@ def _normalize_xyz_triplet(
     value: float | Sequence[float],
 ) -> tuple[float, float, float]:
     """Normalize a scalar or 3-element sequence to a length-3 tuple."""
-    # If the value is a scalar, return a tuple with the same value repeated three times.
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        if len(value) != 3:
+            raise ValueError(
+                "Value must be a scalar or length-3 sequence of floating point values."
+            )
+        # If the value is a scalar, return a tuple with the same value repeated three times.
         return (float(value[0]), float(value[1]), float(value[2]))
     return (float(value), float(value), float(value))
 

--- a/qiskit_addon_utils/problem_generators/generate_xyz_hamiltonian.py
+++ b/qiskit_addon_utils/problem_generators/generate_xyz_hamiltonian.py
@@ -252,7 +252,7 @@ def _validate_xyz_input(value: float | Sequence[float] | dict, *, name: str) -> 
 
 
 def _validate_edge_dict_keys(
-    coupling_constants: dict[tuple[int, int], float | Sequence[float]],
+    coupling_constants: float | Sequence[float] | dict[tuple[int, int], float | Sequence[float]],
 ) -> None:
     """Validate that dict-based edge couplings use valid edge keys."""
     if not isinstance(coupling_constants, dict):
@@ -264,14 +264,10 @@ def _validate_edge_dict_keys(
 
 def _normalize_xyz_triplet(
     value: float | Sequence[float],
-    *,
-    name: str,
 ) -> tuple[float, float, float]:
     """Normalize a scalar or 3-element sequence to a length-3 tuple."""
     # If the value is a scalar, return a tuple with the same value repeated three times.
     if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
-        if len(value) != 3:
-            raise ValueError(f"{name} must be a scalar or length-3 sequence of floats.")
         return (float(value[0]), float(value[1]), float(value[2]))
     return (float(value), float(value), float(value))
 
@@ -289,21 +285,21 @@ def _normalize_edge_key(edge: tuple[int, int]) -> tuple[int, int]:
 
 
 def _normalize_coupling_constants(
-    coupling_constants,
-    colored_edges,
-):
+    coupling_constants: float | Sequence[float] | dict[tuple[int, int], float | Sequence[float]],
+    colored_edges: list[tuple[tuple[int, int], int]],
+) -> dict[tuple[int, int], tuple[float, float, float]]:
+    """Return a per-edge (Jx, Jy, Jz) mapping for every edge."""
     if isinstance(coupling_constants, dict):
-        normalized = {}
+        normalized: dict[tuple[int, int], tuple[float, float, float]] = {}
         for edge, value in coupling_constants.items():
             canonical_edge = _normalize_edge_key(edge)
-            triplet = _normalize_xyz_triplet(value, name="coupling_constants")
+            triplet = _normalize_xyz_triplet(value)
 
             if canonical_edge in normalized:
                 if normalized[canonical_edge] != triplet:
                     raise ValueError(
                         f"coupling_constants contains conflicting values for edge {canonical_edge}."
                     )
-                # same value -> harmless duplicate, keep the existing entry
                 continue
 
             normalized[canonical_edge] = triplet
@@ -313,7 +309,7 @@ def _normalize_coupling_constants(
             edge_map[edge] = normalized.get(_normalize_edge_key(edge), (0.0, 0.0, 0.0))
         return edge_map
 
-    triple = _normalize_xyz_triplet(coupling_constants, name="coupling_constants")
+    triple = _normalize_xyz_triplet(coupling_constants)
     return {edge: triple for edge, _ in colored_edges}
 
 
@@ -327,8 +323,8 @@ def _normalize_ext_magnetic_field(
         for qubit, value in ext_magnetic_field.items():
             if not isinstance(qubit, int):
                 raise ValueError("Magnetic field keys must be integer qubit indices.")
-            normalized[qubit] = _normalize_xyz_triplet(value, name="ext_magnetic_field")
+            normalized[qubit] = _normalize_xyz_triplet(value)
         return {qubit: normalized.get(qubit, (0.0, 0.0, 0.0)) for qubit in range(num_qubits)}
 
-    triple = _normalize_xyz_triplet(ext_magnetic_field, name="ext_magnetic_field")
+    triple = _normalize_xyz_triplet(ext_magnetic_field)
     return {qubit: triple for qubit in range(num_qubits)}

--- a/test/problem_generators/test_generate_xyz_hamiltonian.py
+++ b/test/problem_generators/test_generate_xyz_hamiltonian.py
@@ -130,3 +130,80 @@ class TestProblemGeneration(unittest.TestCase):
                 "External magnetic field must be specified by a length-3 sequence of floating point values.",
                 e_info.value.args[0],
             )
+        with self.subTest("Uniform scalar coupling and field"):
+            lattice = CouplingMap.from_line(3)
+            ham = generate_xyz_hamiltonian(
+                lattice,
+                coupling_constants=1.0,
+                ext_magnetic_field=0.5,
+            )
+
+            target_obs = SparsePauliOp(
+                [
+                    "XXI",
+                    "YYI",
+                    "ZZI",
+                    "IXX",
+                    "IYY",
+                    "IZZ",
+                    "XII",
+                    "YII",
+                    "ZII",
+                    "IXI",
+                    "IYI",
+                    "IZI",
+                    "IIX",
+                    "IIY",
+                    "IIZ",
+                ],
+                coeffs=[1.0] * 6 + [0.5] * 9,
+            )
+            self.assertEqual(target_obs, ham)
+
+        with self.subTest("Edge-specific coupling_constants dict"):
+            lattice = CouplingMap.from_line(3)
+            ham = generate_xyz_hamiltonian(
+                lattice,
+                coupling_constants={
+                    (0, 1): (0.1, 0.0, 0.0),
+                    (1, 2): (0.0, 0.2, 0.0),
+                },
+                ext_magnetic_field=0.0,
+            )
+
+            target_obs = SparsePauliOp(
+                ["XXI", "IYY"],
+                coeffs=[0.1, 0.2],
+            )
+            self.assertEqual(target_obs, ham)
+
+        with self.subTest("Site-specific ext_magnetic_field dict"):
+            lattice = CouplingMap.from_line(3)
+            ham = generate_xyz_hamiltonian(
+                lattice,
+                coupling_constants=0.0,
+                ext_magnetic_field={
+                    0: (0.3, 0.0, 0.0),
+                    2: (0.0, 0.4, 0.0),
+                },
+            )
+
+            target_obs = SparsePauliOp(
+                ["XII", "IIY"],
+                coeffs=[0.3, 0.4],
+            )
+            self.assertEqual(target_obs, ham)
+
+        with self.subTest("Invalid dict tuple length raises ValueError"):
+            lattice = CouplingMap.from_line(3)
+            with pytest.raises(ValueError):
+                generate_xyz_hamiltonian(
+                    lattice,
+                    coupling_constants={(0, 1): (1.0, 2.0)},
+                )
+
+            with pytest.raises(ValueError):
+                generate_xyz_hamiltonian(
+                    lattice,
+                    ext_magnetic_field={0: (1.0, 2.0)},
+                )

--- a/test/problem_generators/test_generate_xyz_hamiltonian.py
+++ b/test/problem_generators/test_generate_xyz_hamiltonian.py
@@ -119,7 +119,7 @@ class TestProblemGeneration(unittest.TestCase):
             with pytest.raises(ValueError) as e_info:
                 generate_xyz_hamiltonian(lattice, coupling_constants=(1.0, 1.0))
             self.assertEqual(
-                "Coupling constants must be specified by a length-3 sequence of floating point values.",
+                "Coupling constants must be specified by a length-3 sequence of scalar or floating point values.",
                 e_info.value.args[0],
             )
         with self.subTest("Bad magnetic field"):
@@ -127,7 +127,7 @@ class TestProblemGeneration(unittest.TestCase):
             with pytest.raises(ValueError) as e_info:
                 generate_xyz_hamiltonian(lattice, ext_magnetic_field=(1.0, 1.0))
             self.assertEqual(
-                "External magnetic field must be specified by a length-3 sequence of floating point values.",
+                "External magnetic field must be specified by a length-3 sequence of scalar or floating point values.",
                 e_info.value.args[0],
             )
         with self.subTest("Uniform scalar coupling and field"):

--- a/test/problem_generators/test_generate_xyz_hamiltonian.py
+++ b/test/problem_generators/test_generate_xyz_hamiltonian.py
@@ -140,21 +140,21 @@ class TestProblemGeneration(unittest.TestCase):
 
             target_obs = SparsePauliOp(
                 [
-                    "XXI",
-                    "YYI",
-                    "ZZI",
                     "IXX",
                     "IYY",
                     "IZZ",
-                    "XII",
-                    "YII",
-                    "ZII",
-                    "IXI",
-                    "IYI",
-                    "IZI",
+                    "XXI",
+                    "YYI",
+                    "ZZI",
                     "IIX",
                     "IIY",
                     "IIZ",
+                    "IXI",
+                    "IYI",
+                    "IZI",
+                    "XII",
+                    "YII",
+                    "ZII",
                 ],
                 coeffs=[1.0] * 6 + [0.5] * 9,
             )
@@ -172,7 +172,7 @@ class TestProblemGeneration(unittest.TestCase):
             )
 
             target_obs = SparsePauliOp(
-                ["XXI", "IYY"],
+                ["IXX", "YYI"],
                 coeffs=[0.1, 0.2],
             )
             self.assertEqual(target_obs, ham)
@@ -189,7 +189,7 @@ class TestProblemGeneration(unittest.TestCase):
             )
 
             target_obs = SparsePauliOp(
-                ["XII", "IIY"],
+                ["IIX", "YII"],
                 coeffs=[0.3, 0.4],
             )
             self.assertEqual(target_obs, ham)
@@ -207,3 +207,26 @@ class TestProblemGeneration(unittest.TestCase):
                     lattice,
                     ext_magnetic_field={0: (1.0, 2.0)},
                 )
+
+        with self.subTest("Duplicate edge entries with different coefficients raise ValueError"):
+            lattice = CouplingMap.from_line(3)
+            with pytest.raises(ValueError):
+                generate_xyz_hamiltonian(
+                    lattice,
+                    coupling_constants={(0, 1): 1.0, (1, 0): 2.0},
+                    ext_magnetic_field=0.0,
+                )
+
+        with self.subTest("Duplicate edge entries with same coefficients are allowed"):
+            lattice = CouplingMap.from_line(3)
+            ham = generate_xyz_hamiltonian(
+                lattice,
+                coupling_constants={(0, 1): 1.0, (1, 0): 1.0},
+                ext_magnetic_field=0.0,
+            )
+
+            target_obs = SparsePauliOp(
+                ["IXX", "IYY", "IZZ"],
+                coeffs=[1.0, 1.0, 1.0],
+            )
+            self.assertEqual(target_obs, ham)


### PR DESCRIPTION
## Summary
This PR extends `generate_xyz_hamiltonian` to accept arbitrary per-edge and per-site coefficients, replacing the previous restriction to a single uniform scalar or length-3 sequence.

### What changed
- `coupling_constants` now accepts a `dict[tuple[int, int], float | Sequence[float]]`, mapping individual graph edges to their own `(Jxx, Jyy, Jzz)` triplet. Edges not present in the dict default to `(0.0, 0.0, 0.0)`.

- `ext_magnetic_field` now accepts a `dict[int, float | Sequence[float]]`, mapping individual qubit indices to their own `(hx, hy, hz)` triplet. Qubits not present in the dict default to `(0.0, 0.0, 0.0)`.

Both parameters remain fully backward-compatible — scalar and length-3 sequence inputs continue to work as before (uniform application across all edges/qubits).

### Validation added
- `_validate_xyz_input `— rejects non-dict sequences whose length ≠ 3 before normalization
- `_validate_edge_dict_keys `— rejects dict keys that are not (int, int) tuples
- `_normalize_edge_key `— canonicalises (i, j) / (j, i) so both orderings resolve to the same edge; raises on malformed keys
- `_normalize_coupling_constants` — raises on conflicting values for the same canonical edge (e.g. both (0, 1) and (1, 0) supplied with different coefficients)
- `_normalize_ext_magnetic_field` — raises if dict keys are not integers
All reachable `ValueError` paths are documented in the Raises section of the public docstring.

### Tests
Unit tests cover:
- Uniform scalar / length-3 sequence inputs (existing behaviour)
- Dict-based per-edge coupling constants (valid keys, default fallback, both orderings of the same edge)
- Dict-based per-qubit external magnetic field (valid keys, default fallback)
- All ValueError error paths

Fixes #34 