### PR TITLE
Add merge_group trigger to workflows with required checks

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - 'stable/**'
+  merge_group:
 
 jobs:
   coverage:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,6 +12,7 @@ on:
     branches:
       - main
       - 'stable/**'
+  merge_group:
 
 jobs:
   build:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - 'stable/**'
+  merge_group:
 
 jobs:
   lint:

--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - 'stable/**'
+  merge_group:
   schedule:
     - cron: '0 1 * * *'
 

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - 'stable/**'
+  merge_group:
   schedule:
     - cron: '0 1 * * *'
 

--- a/.github/workflows/test_minimum_versions.yml
+++ b/.github/workflows/test_minimum_versions.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - 'stable/**'
+  merge_group:
 
 jobs:
   tests:


### PR DESCRIPTION
This PR is a prerequisite for enabling merge groups in this repository.  The Qiskit SDK uses them, and I've been experimenting with them in Qiskit.jl.  What I like about them is that they require the actual commit being pushed to `main` to pass CI.

The following text and code were generated by Claude Opus 5.

<hr>

### Summary

Adds a `merge_group:` trigger to the six workflows that produce required status checks, so that a GitHub merge queue can be enabled on this repository.

### Why this is needed

A merge queue dispatches the `merge_group` event against a transient ref of the form `refs/heads/gh-readonly-queue/<base>/pr-<N>-<sha>`. A workflow that only listens for `push` and `pull_request` therefore **never runs** for a queued batch. Any required status check produced by such a workflow stays permanently pending, and the merge group eventually times out and fails.

So every workflow producing a required check needs `merge_group:` before the queue is turned on.

### What changed

| Workflow | Required check(s) it produces |
| --- | --- |
| `lint.yml` | `lint check` |
| `test_latest_versions.yml` | `latest version tests` × 7 (ubuntu 3.10–3.13, macos-latest 3.13, windows-latest 3.13) |
| `test_minimum_versions.yml` | `minimum version tests (ubuntu-latest, 3.10)` |
| `test_development_versions.yml` | `development version tests` (ubuntu-latest 3.10, 3.13) |
| `docs.yml` | `build docs` |
| `coverage.yml` | `code coverage (ubuntu-latest, 3.11)` |

Each gets a single added line. No job definitions, matrices, or steps were modified.

### Deliberately not changed

- **`citation.yml`** — produces no required check, and it uses `paths:` filters. `merge_group` does not support `paths:` filtering, so adding the trigger would run the LaTeX/BibTeX build on every queued batch regardless of whether `CITATION.bib` changed.
- **`release.yml`** — driven by tag pushes and `workflow_dispatch`; not part of PR validation.

### Verification

All 12 required contexts from the `Default branch rules` ruleset were expanded over their job matrices and cross-checked against the workflows that produce them; each one now resolves to a `merge_group`-enabled workflow. All six files were confirmed to parse as valid YAML with the expected trigger set.

### Notes for reviewers

- **Docs deployment is unaffected.** The `deploy` job in `docs.yml` is gated on `github.ref == 'refs/heads/stable/0.4'`, which is never true for a `gh-readonly-queue/...` ref, so it is skipped inside the queue. It continues to run on the real `push` that the queue produces when it merges a batch into the base branch, exactly as it does today.
- **Coverage uploads.** `coverage.yml` reports to Coveralls on every run, so enabling the queue means one additional upload per PR, associated with the transient queue ref. This does not block merges, but it may add some noise to Coveralls history. Left as-is here rather than bundled into this change.
- **Cosmetic:** in a merge-group run, the reno step in `docs.yml` names the upcoming release after `GITHUB_REF_NAME`, which will read `gh-readonly-queue/main/pr-N-<sha>`. These docs are only ever uploaded as an artifact and never deployed. This quirk already exists for `pull_request` runs (where the ref name is `<N>/merge`), so it is pre-existing rather than introduced here.

### Follow-up (repository settings, not code)

Merging this PR does not by itself enable the queue — that is a branch-ruleset change that has to be made in the repository settings, and it should be done *after* this lands so the required checks are already wired up. A decision is still needed on whether to enable the queue for `main` only, or for `main` and `stable/**`.
