### PR TITLE
Fix pyXYZ-notebook and pyXYZ-doctest tox environments

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,20 @@ commands =
   nbqa pylint -rn docs/
   reno lint
 
-[testenv:{,py-,py3-,py310-,py311-,py312-,py313-}notebook]
+# NOTE: Keep the hyphen *outside* the braces, and do not nest braces.
+#
+# Writing this as `{,py310-,py311-,...}notebook` silently produces the wrong
+# environments.  tox runs `expand_ranges()` over the section name before
+# splitting on braces, and its range regex reads the trailing hyphen of each
+# brace element as an open-ended numeric range: `py313-` parses as `py3` plus
+# the range `13-`, which expands to `13,14,...` up to tox's newest known Python.
+# The section then defines junk envs (`13notebook`, `pynotebook`, ...) and never
+# defines `py313-notebook`, so `tox -e py313-notebook` silently falls back to
+# the generic [testenv] and runs the unit tests instead of the notebooks.
+#
+# Nesting (`{notebook,{py310,py311}-notebook}`) is not supported either -- tox's
+# brace regexes cannot span an inner `}` and it crashes with a ValueError.
+[testenv:{notebook,py310-notebook,py311-notebook,py312-notebook,py313-notebook}]
 extras =
   nbtest
   notebook-dependencies
@@ -48,7 +61,8 @@ commands =
          --ignore=docs/how_tos/postselection_with_bit_flip_checks.ipynb \
          {posargs} docs/
 
-[testenv:{,py-,py3-,py310-,py311-,py312-,py313-}doctest]
+# See the note above the notebook environments regarding this spelling.
+[testenv:{doctest,py310-doctest,py311-doctest,py312-doctest,py313-doctest}]
 extras =
   test
   doctest


### PR DESCRIPTION
This PR was generated by Claude Opus 5 under my guidance.

<hr>

### Summary

The `pyXYZ-notebook` and `pyXYZ-doctest` tox environments did not do what their section names suggest. None of `py310-notebook` through `py313-notebook` ever ran a notebook — each silently ran the plain unit test suite instead.

### The bug

tox's factor parser calls `expand_ranges()` on a section name *before* splitting it on braces ([`factor.py`](https://github.com/tox-dev/tox/blob/main/src/tox/config/loader/ini/factor.py)). That function's regex treats `\d+-` as an open-ended numeric range, and it does not know that the hyphen here is a factor separator. So in:

```ini
[testenv:{,py-,py3-,py310-,py311-,py312-,py313-}notebook]
```

`py313-` parses as `py3` plus the range `13-`, which expands up to tox's newest known Python minor version. The section name became:

```
{,py-,py3,4,5,6,7,8,9,10,11,12,13,14,py,py,py,py}notebook
```

That defines 18 names — 13 of them junk (`4notebook` … `14notebook`, `pynotebook`) plus 3 duplicates — and never defines `py310-notebook` … `py313-notebook`.

Because those names were absent from tox's section mapping, `tox -e py313-notebook` fell back to the generic `[testenv]` and ran `pytest` with `extras = test`. The names were still listed in `envlist`, so a bare `tox` ran the unit tests four extra times and never executed a notebook. `tox l` showed the junk environments, which is what originally gave this away.

The junk set also drifts with tox upgrades, since the upper bound comes from tox's own `LATEST_PYTHON_MINOR_MAX` (currently 14).

### The fix

Spell both section names out with the hyphen *outside* the braces, which passes through `expand_ranges()` unchanged:

```ini
[testenv:{notebook,py310-notebook,py311-notebook,py312-notebook,py313-notebook}]
[testenv:{doctest,py310-doctest,py311-doctest,py312-doctest,py313-doctest}]
```

Nesting braces is **not** a viable alternative — `{notebook,{py310,py311}-notebook}` crashes tox with an uncaught `ValueError` on any command, including `tox l`, because both brace regexes use `[^}]+` and cannot span an inner `}`. There is a comment in `tox.ini` recording this so it is not retried.

The `py-` and `py3-` variants are dropped. They resolved to the same interpreter as the bare `notebook` / `doctest` environments, so they added nothing.

### Verification

`tox l` no longer lists any junk environments:

```
default environments:
py310, py310-notebook, py311, py311-notebook,
py312, py312-notebook, py313, py313-notebook,
lint, coverage, docs, doctest

additional environments:
style, notebook, py310-doctest, py311-doctest,
py312-doctest, py313-doctest, docs-clean
```

- `tox c -e py313-notebook` now reports `extras = nbtest, notebook-dependencies` (previously `test`).
- `tox c -e py312-notebook` now reports the `--nbmake` command (previously bare `pytest`).
- `tox -e py312-notebook` runs end to end: Python 3.12.14, nbmake installed, 2 notebooks executed and passed.
- `tox -e lint` passes.

### Impact on CI

None. All three workflows invoke `tox -e py,notebook,doctest`, and the bare `notebook` and `doctest` names were among those that always resolved correctly. This fix matters for anyone running a bare `tox`, or naming a versioned notebook/doctest environment explicitly.

No release note is included, as this is a developer-tooling change with no user-facing effect. Happy to add one if preferred.

### A possible follow-up

This class of bug is silent by construction — the environment exists, runs, and passes, just with the wrong configuration. A small CI check that runs `tox l` and diffs it against an expected environment list would catch any recurrence. Glad to add that separately if it seems worthwhile.
