### PR TITLE
Add official support for Python 3.14

### DIFF
--- a/.github/workflows/test_development_versions.yml
+++ b/.github/workflows/test_development_versions.yml
@@ -21,7 +21,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.13"]
+        python-version: ["3.10", "3.14"]
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test_latest_versions.yml
+++ b/.github/workflows/test_latest_versions.yml
@@ -21,12 +21,12 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
         include:
           - os: macos-latest
-            python-version: "3.13"
+            python-version: "3.14"
           - os: windows-latest
-            python-version: "3.13"
+            python-version: "3.14"
     steps:
       - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Physics",
 ]
 

--- a/releasenotes/notes/python-3.14-34719989ce1be371.yaml
+++ b/releasenotes/notes/python-3.14-34719989ce1be371.yaml
@@ -1,0 +1,5 @@
+---
+other:
+  - |
+    This release adds support for Python 3.14.  No code changes were necessary,
+    so older releases are expected to work on Python 3.14 too.

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 4.4.3
-envlist = py{310,311,312,313}{,-notebook}, lint, coverage, docs, doctest
+envlist = py{310,311,312,313,314}{,-notebook}, lint, coverage, docs, doctest
 isolated_build = True
 
 [testenv]
@@ -38,7 +38,7 @@ commands =
   nbqa pylint -rn docs/
   reno lint
 
-[testenv:{,py-,py3-,py310-,py311-,py312-,py313-}notebook]
+[testenv:{,py-,py3-,py310-,py311-,py312-,py313-,py314-}notebook]
 extras =
   nbtest
   notebook-dependencies
@@ -48,7 +48,7 @@ commands =
          --ignore=docs/how_tos/postselection_with_bit_flip_checks.ipynb \
          {posargs} docs/
 
-[testenv:{,py-,py3-,py310-,py311-,py312-,py313-}doctest]
+[testenv:{,py-,py3-,py310-,py311-,py312-,py313-,py314-}doctest]
 extras =
   test
   doctest


### PR DESCRIPTION
This PR was generated by Claude Opus 5 under my guidance

<hr>

Adds official support for Python 3.14. No code changes were necessary — the existing test suite passes unmodified.

Changes:

- Add the `Programming Language :: Python :: 3.14` classifier in `pyproject.toml`
- Extend the tox `envlist` to `py314`, and add the `py314-` factor to the `notebook` and `doctest` environments
- Add `3.14` to the latest-version CI matrix, and bump the macOS and Windows jobs from 3.13 to 3.14 (they track the newest supported version)
- Bump the development-version CI matrix from `["3.10", "3.13"]` to `["3.10", "3.14"]`
- Add a release note

This follows the same approach as Qiskit/qiskit-addon-sqd#310.

Verified locally on Python 3.14: `tox -e py314` and `tox -e py314-doctest` both pass (254 tests), and `tox -e lint` is clean.

Note that the `notebook`/`doctest` `testenv` factor lists retain the existing trailing-hyphen-inside-braces style; the cleanup of that pattern is left to #214.